### PR TITLE
feat: notification drawer with toast bridge, snackbar redesign, and error detail enrichment

### DIFF
--- a/services/backend/app/routers/admin/github.py
+++ b/services/backend/app/routers/admin/github.py
@@ -287,6 +287,7 @@ async def get_all_users(
                 editor_width_percentage=user.editor_width_percentage,
                 tab_position=user.tab_position or "above",
                 tab_sort_order=user.tab_sort_order or "name",
+                recents_tab_limit=user.recents_tab_limit if user.recents_tab_limit is not None else 10,
                 current_doc_id=user.current_doc_id,
                 current_document=None  # Don't load documents for user list
             ))

--- a/services/ui/src/api/api.js
+++ b/services/ui/src/api/api.js
@@ -223,12 +223,26 @@ export class Api {
       if (now - this.lastNotificationTime > this.notificationCooldown) {
         this.lastNotificationTime = now;
 
+        // Extract backend error detail for richer notifications
+        let errorDetails = null;
+        const responseData = error.response?.data;
+        if (responseData) {
+          const backendDetail = responseData.detail || responseData.message || responseData.error;
+          if (backendDetail) {
+            const endpoint = _endpoint || error.config?.url || 'unknown';
+            const status = error.response?.status || 'N/A';
+            errorDetails = `Endpoint: ${endpoint}\nStatus: ${status}\nDetail: ${typeof backendDetail === 'string' ? backendDetail : JSON.stringify(backendDetail)}`;
+          }
+        }
+
         // Dispatch custom notification event
         window.dispatchEvent(new CustomEvent('notification', {
           detail: {
             message: notificationMessage,
             type: notificationType,
-            duration: 15000 // Show for 15 seconds for backend issues
+            duration: 8000,
+            details: errorDetails,
+            errorType: error.code === 'ERR_NETWORK' || !error.response ? 'network' : 'system'
           }
         }));
       }

--- a/services/ui/src/api/notificationsApi.js
+++ b/services/ui/src/api/notificationsApi.js
@@ -43,6 +43,11 @@ class NotificationsApi extends Api {
     const response = await this.apiCall('/notifications', 'DELETE');
     return response.data;
   }
+
+  async create({ title, message, category = 'info', link = null, detail = null }) {
+    const response = await this.apiCall('/notifications', 'POST', { title, message, category, link, detail });
+    return response.data;
+  }
 }
 
 export default new NotificationsApi();

--- a/services/ui/src/components/App.jsx
+++ b/services/ui/src/components/App.jsx
@@ -16,7 +16,7 @@ import { markDraftAcknowledged } from "@/hooks/document/useSaveDocument";
 
 function App() {
   const { autosaveEnabled, syncPreviewScrollEnabled, isInitializing } = useAuth();
-  const { currentDocument, saveDocument, migrationStatus, content, isSharedView, sharedDocument, sharedLoading, loading, triggerContentUpdate, cursorLine, fullscreenPreview, setFullscreenPreview, showIconBrowser, setShowIconBrowser, showChatDrawer, setShowChatDrawer } = useDocumentContext();
+  const { currentDocument, saveDocument, migrationStatus, content, isSharedView, sharedDocument, sharedLoading, loading, triggerContentUpdate, cursorLine, fullscreenPreview, setFullscreenPreview, showIconBrowser, setShowIconBrowser, showChatDrawer, setShowChatDrawer, createDocument } = useDocumentContext();
 
   // --- Draft promotion modal state ---
   const [showPromoteDraft, setShowPromoteDraft] = useState(false);
@@ -103,8 +103,8 @@ function App() {
   // Check for new deployments and prompt user to refresh
   useVersionCheck();
 
-  // Setup global keyboard shortcuts (Ctrl+S, etc.)
-  useGlobalKeyboardShortcuts({ onDraftPromote: handleDraftPromote });
+  // Setup global keyboard shortcuts (Ctrl+S, Ctrl+Alt+N, etc.)
+  useGlobalKeyboardShortcuts({ onDraftPromote: handleDraftPromote, onNewDocument: createDocument });
 
   // Debug fullscreen state changes
   useEffect(() => {

--- a/services/ui/src/components/NotificationProvider.jsx
+++ b/services/ui/src/components/NotificationProvider.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react";
 import { Toast, ToastContainer } from "react-bootstrap";
+import notificationsApi from "@/api/notificationsApi";
 
 const NotificationContext = createContext();
 
@@ -7,31 +8,57 @@ export function useNotification() {
   return useContext(NotificationContext);
 }
 
+// Map toast variant types to backend notification categories
+const TOAST_TYPE_TO_CATEGORY = {
+  danger: 'error',
+  warning: 'warning',
+  success: 'success',
+  info: 'info',
+};
+
 export function NotificationProvider({ children }) {
   const [toasts, setToasts] = useState([]);
 
 
 
-  const showNotification = useCallback((message, type = "info", duration = 5000, details = null, errorType = null) => {
+  const showNotification = useCallback((message, type = "info", duration = 3000, details = null, errorType = null, { persist } = {}) => {
     // Log to console for debugging
     console.log(`[Notification] ${type}: ${message}`);
-    // Increase duration for warnings/errors
+    // Shorter durations now that important toasts persist to notification drawer
     let effectiveDuration = duration;
     if (type === "danger" || type === "warning") {
-      effectiveDuration = Math.max(duration, 10000);
+      effectiveDuration = Math.max(duration, 5000);
     }
     const id = Date.now() + Math.random();
     setToasts((prev) => [...prev, { id, message, type, details, errorType }]);
     setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id));
     }, effectiveDuration);
+
+    // Bridge to persistent notification system:
+    // By default, persist danger/warning toasts. Callers can override with persist flag.
+    const shouldPersist = persist !== undefined ? persist : (type === "danger" || type === "warning");
+    if (shouldPersist) {
+      const category = TOAST_TYPE_TO_CATEGORY[type] || 'info';
+      notificationsApi.create({
+        title: 'Notification',
+        message,
+        category,
+        detail: details || null,
+      }).then(() => {
+        // Signal useNotifications to refresh immediately
+        window.dispatchEvent(new CustomEvent('notification-created'));
+      }).catch(() => {
+        // Fire-and-forget — don't disrupt UX if persist fails
+      });
+    }
   }, []);
 
   const contextValue = useMemo(() => ({
-    showSuccess: (msg, duration) => showNotification(msg, "success", duration),
-    showError: (msg, duration, details, errorType) => showNotification(msg, "danger", duration, details, errorType),
-    showWarning: (msg, duration, details, errorType) => showNotification(msg, "warning", duration, details, errorType),
-    showInfo: (msg, duration) => showNotification(msg, "info", duration),
+    showSuccess: (msg, duration, opts) => showNotification(msg, "success", duration, null, null, opts),
+    showError: (msg, duration, details, errorType, opts) => showNotification(msg, "danger", duration, details, errorType, opts),
+    showWarning: (msg, duration, details, errorType, opts) => showNotification(msg, "warning", duration, details, errorType, opts),
+    showInfo: (msg, duration, opts) => showNotification(msg, "info", duration, null, null, opts),
   }), [showNotification]);
 
   useEffect(() => {
@@ -62,7 +89,7 @@ export function NotificationProvider({ children }) {
   return (
     <NotificationContext.Provider value={contextValue}>
       {children}
-      <ToastContainer position="bottom-end" className="p-3" style={{ zIndex: 9999 }}>
+      <ToastContainer position="top-center" className="p-3" style={{ zIndex: 9999 }}>
         {toasts.map((toast) => {
           const defaultIcon = toast.type === "success" ? "bi-check-circle-fill" :
                              toast.type === "danger" ? "bi-exclamation-triangle-fill" :
@@ -77,7 +104,7 @@ export function NotificationProvider({ children }) {
               bg={toast.type}
               show={true}
               onClose={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
-              delay={toast.type === "danger" || toast.type === "warning" ? 10000 : 5000}
+              delay={toast.type === "danger" || toast.type === "warning" ? 5000 : 3000}
               autohide
             >
               <Toast.Header closeButton onClick={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}>

--- a/services/ui/src/components/NotificationProvider.jsx
+++ b/services/ui/src/components/NotificationProvider.jsx
@@ -1,5 +1,4 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react";
-import { Toast, ToastContainer } from "react-bootstrap";
 import notificationsApi from "@/api/notificationsApi";
 
 const NotificationContext = createContext();
@@ -40,11 +39,14 @@ export function NotificationProvider({ children }) {
     const shouldPersist = persist !== undefined ? persist : (type === "danger" || type === "warning");
     if (shouldPersist) {
       const category = TOAST_TYPE_TO_CATEGORY[type] || 'info';
+      const safeDetail = details != null
+        ? (typeof details === 'string' ? details : JSON.stringify(details))
+        : null;
       notificationsApi.create({
         title: 'Notification',
         message,
         category,
-        detail: details || null,
+        detail: safeDetail,
       }).then(() => {
         // Signal useNotifications to refresh immediately
         window.dispatchEvent(new CustomEvent('notification-created'));
@@ -86,10 +88,19 @@ export function NotificationProvider({ children }) {
     }
   };
 
+  const getSnackbarVariant = (type) => {
+    switch (type) {
+      case 'success': return 'snackbar--success';
+      case 'danger': return 'snackbar--error';
+      case 'warning': return 'snackbar--warning';
+      default: return 'snackbar--info';
+    }
+  };
+
   return (
     <NotificationContext.Provider value={contextValue}>
       {children}
-      <ToastContainer position="top-center" className="p-3" style={{ zIndex: 9999 }}>
+      <div className="snackbar-container">
         {toasts.map((toast) => {
           const defaultIcon = toast.type === "success" ? "bi-check-circle-fill" :
                              toast.type === "danger" ? "bi-exclamation-triangle-fill" :
@@ -99,40 +110,25 @@ export function NotificationProvider({ children }) {
           const iconClass = getErrorIcon(toast.errorType, defaultIcon);
 
           return (
-            <Toast
+            <div
               key={toast.id}
-              bg={toast.type}
-              show={true}
-              onClose={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
-              delay={toast.type === "danger" || toast.type === "warning" ? 5000 : 3000}
-              autohide
+              className={`snackbar ${getSnackbarVariant(toast.type)}`}
+              role="alert"
             >
-              <Toast.Header closeButton onClick={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}>
-                <i className={`bi me-2 ${iconClass}`}></i>
-                <strong className="me-auto">Notification</strong>
-              </Toast.Header>
-              <Toast.Body className={toast.type === "warning" || toast.type === "info" ? "text-dark" : "text-white"}>
-                {toast.message}
-                {toast.details && (
-                  <div className="mt-2">
-                    <button
-                      className="btn btn-sm btn-outline-secondary"
-                      onClick={() => {
-                        // Create a modal or detailed view for error details
-                        console.log('Error details:', toast.details);
-                        // For now, just log to console - could implement a modal later
-                      }}
-                    >
-                      <i className="bi bi-info-circle me-1"></i>
-                      Show Details
-                    </button>
-                  </div>
-                )}
-              </Toast.Body>
-            </Toast>
+              <span className="snackbar-accent" />
+              <i className={`bi ${iconClass} snackbar-icon`} />
+              <span className="snackbar-message">{toast.message}</span>
+              <button
+                className="snackbar-dismiss"
+                onClick={() => setToasts((prev) => prev.filter((t) => t.id !== toast.id))}
+                aria-label="Dismiss"
+              >
+                <i className="bi bi-x" />
+              </button>
+            </div>
           );
         })}
-      </ToastContainer>
+      </div>
     </NotificationContext.Provider>
   );
 }

--- a/services/ui/src/components/toolbar/NotificationDropdown.jsx
+++ b/services/ui/src/components/toolbar/NotificationDropdown.jsx
@@ -1,10 +1,36 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, Badge } from 'react-bootstrap';
+import { Offcanvas, Badge, Button, ButtonGroup, Form } from 'react-bootstrap';
 import { formatDistanceToNow } from 'date-fns';
 
+const SEVERITY_ORDER = ['error', 'warning', 'info', 'success'];
+
+const SEVERITY_CONFIG = {
+  error: { icon: 'bi-x-circle', label: 'Errors', dotClass: 'notification-severity-dot--error' },
+  warning: { icon: 'bi-exclamation-triangle', label: 'Warnings', dotClass: 'notification-severity-dot--warning' },
+  info: { icon: 'bi-info-circle', label: 'Info', dotClass: 'notification-severity-dot--info' },
+  success: { icon: 'bi-check-circle', label: 'Success', dotClass: 'notification-severity-dot--success' },
+};
+
+const VIEW_KEY = 'notification-drawer-view';
+
+function getHighestSeverity(notifications) {
+  for (const severity of SEVERITY_ORDER) {
+    if (notifications.some(n => !n.is_read && n.category === severity)) return severity;
+  }
+  return null;
+}
+
+function getBadgeBg(severity) {
+  switch (severity) {
+    case 'error': return 'danger';
+    case 'warning': return 'warning';
+    default: return 'primary';
+  }
+}
+
 /**
- * NotificationDropdown — Toolbar dropdown showing recent notifications.
+ * NotificationDropdown — Slide-out notification drawer (Offcanvas).
  */
 function NotificationDropdown({
   notifications,
@@ -16,24 +42,48 @@ function NotificationDropdown({
   onViewDetail,
 }) {
   const [show, setShow] = useState(false);
+  const [viewMode, setViewMode] = useState(() => {
+    try { return localStorage.getItem(VIEW_KEY) || 'timeline'; } catch { return 'timeline'; }
+  });
+  const [unreadOnly, setUnreadOnly] = useState(false);
 
-  const handleToggle = (isOpen) => {
-    setShow(isOpen);
-  };
+  const handleViewChange = useCallback((mode) => {
+    setViewMode(mode);
+    try { localStorage.setItem(VIEW_KEY, mode); } catch { /* silent */ }
+  }, []);
+
+  const highestSeverity = useMemo(() => getHighestSeverity(notifications), [notifications]);
+  const badgeBg = useMemo(() => getBadgeBg(highestSeverity), [highestSeverity]);
+
+  const filtered = useMemo(() => {
+    if (unreadOnly) return notifications.filter(n => !n.is_read);
+    return notifications;
+  }, [notifications, unreadOnly]);
+
+  const grouped = useMemo(() => {
+    if (viewMode !== 'severity') return null;
+    const groups = {};
+    for (const sev of SEVERITY_ORDER) groups[sev] = [];
+    for (const n of filtered) {
+      const cat = SEVERITY_ORDER.includes(n.category) ? n.category : 'info';
+      groups[cat].push(n);
+    }
+    return groups;
+  }, [filtered, viewMode]);
 
   return (
-    <Dropdown show={show} onToggle={handleToggle} align="end">
-      <Dropdown.Toggle
+    <>
+      <Button
         variant="outline-secondary"
         size="sm"
-        id="notification-dropdown"
         title="Notifications"
         className="position-relative"
+        onClick={() => setShow(true)}
       >
         <i className="bi bi-bell" />
         {unreadCount > 0 && (
           <Badge
-            bg="danger"
+            bg={badgeBg}
             pill
             className="position-absolute top-0 start-100 translate-middle"
             style={{ fontSize: '0.6em' }}
@@ -41,16 +91,58 @@ function NotificationDropdown({
             {unreadCount > 99 ? '99+' : unreadCount}
           </Badge>
         )}
-      </Dropdown.Toggle>
+      </Button>
 
-      <Dropdown.Menu className="notification-dropdown-menu">
-        <div className="d-flex justify-content-between align-items-center px-3 py-2 notification-header">
-          <strong>Notifications</strong>
-          <div className="d-flex gap-2">
+      <Offcanvas
+        show={show}
+        onHide={() => setShow(false)}
+        placement="start"
+        scroll
+        backdrop={false}
+        className="notification-drawer"
+      >
+        <Offcanvas.Header closeButton className="notification-drawer-header">
+          <Offcanvas.Title className="notification-drawer-title">
+            <i className="bi bi-bell me-2" />
+            Notifications
+            {unreadCount > 0 && (
+              <Badge bg={badgeBg} pill className="ms-2" style={{ fontSize: '0.7em' }}>
+                {unreadCount}
+              </Badge>
+            )}
+          </Offcanvas.Title>
+        </Offcanvas.Header>
+
+        <div className="notification-drawer-controls px-3 py-2">
+          <div className="d-flex justify-content-between align-items-center">
+            <ButtonGroup size="sm">
+              <Button
+                variant={viewMode === 'timeline' ? 'primary' : 'outline-secondary'}
+                onClick={() => handleViewChange('timeline')}
+              >
+                <i className="bi bi-clock me-1" />Timeline
+              </Button>
+              <Button
+                variant={viewMode === 'severity' ? 'primary' : 'outline-secondary'}
+                onClick={() => handleViewChange('severity')}
+              >
+                <i className="bi bi-funnel me-1" />By Severity
+              </Button>
+            </ButtonGroup>
+            <Form.Check
+              type="switch"
+              id="unread-filter"
+              label="Unread"
+              checked={unreadOnly}
+              onChange={(e) => setUnreadOnly(e.target.checked)}
+              className="notification-unread-toggle"
+            />
+          </div>
+          <div className="d-flex gap-2 mt-2">
             {unreadCount > 0 && (
               <button
                 className="btn btn-link btn-sm p-0 text-decoration-none notification-action-btn"
-                onClick={(e) => { e.stopPropagation(); onMarkAllRead(); }}
+                onClick={onMarkAllRead}
               >
                 Mark all read
               </button>
@@ -58,44 +150,66 @@ function NotificationDropdown({
             {notifications.length > 0 && (
               <button
                 className="btn btn-link btn-sm p-0 text-decoration-none notification-action-btn notification-action-btn--danger"
-                onClick={(e) => { e.stopPropagation(); onClearAll(); }}
+                onClick={onClearAll}
               >
-                Clear
+                Clear all
               </button>
             )}
           </div>
         </div>
 
-        {notifications.length === 0 ? (
-          <div className="text-center notification-empty py-4">
-            <i className="bi bi-bell-slash d-block mb-2" style={{ fontSize: '1.5em' }} />
-            No notifications
-          </div>
-        ) : (
-          notifications.slice(0, 20).map((n) => (
-            <NotificationItem
-              key={n.id}
-              notification={n}
-              onMarkRead={onMarkRead}
-              onDelete={onDelete}
-              onViewDetail={onViewDetail}
-            />
-          ))
-        )}
-      </Dropdown.Menu>
-    </Dropdown>
+        <Offcanvas.Body className="notification-drawer-body p-0">
+          {filtered.length === 0 ? (
+            <div className="text-center notification-empty py-5">
+              <i className="bi bi-bell-slash d-block mb-2" style={{ fontSize: '2em' }} />
+              {unreadOnly ? 'No unread notifications' : 'No notifications'}
+            </div>
+          ) : viewMode === 'severity' && grouped ? (
+            SEVERITY_ORDER.map((sev) => {
+              const items = grouped[sev];
+              if (items.length === 0) return null;
+              const config = SEVERITY_CONFIG[sev];
+              return (
+                <div key={sev} className="notification-group">
+                  <div className={`notification-group-divider notification-group-divider--${sev}`} />
+                  <div className="notification-group-heading px-3 py-2">
+                    <i className={`bi ${config.icon} me-1`} />
+                    <span>{config.label}</span>
+                    <Badge bg="secondary" pill className="ms-2" style={{ fontSize: '0.7em' }}>
+                      {items.length}
+                    </Badge>
+                  </div>
+                  {items.map((n) => (
+                    <NotificationItem
+                      key={n.id}
+                      notification={n}
+                      onMarkRead={onMarkRead}
+                      onDelete={onDelete}
+                      onViewDetail={onViewDetail}
+                    />
+                  ))}
+                </div>
+              );
+            })
+          ) : (
+            filtered.slice(0, 50).map((n) => (
+              <NotificationItem
+                key={n.id}
+                notification={n}
+                onMarkRead={onMarkRead}
+                onDelete={onDelete}
+                onViewDetail={onViewDetail}
+              />
+            ))
+          )}
+        </Offcanvas.Body>
+      </Offcanvas>
+    </>
   );
 }
 
 function NotificationItem({ notification, onMarkRead, onDelete, onViewDetail }) {
-  const categoryIcons = {
-    info: 'bi-info-circle text-info',
-    success: 'bi-check-circle text-success',
-    warning: 'bi-exclamation-triangle text-warning',
-    error: 'bi-x-circle text-danger',
-  };
-
-  const icon = categoryIcons[notification.category] || categoryIcons.info;
+  const config = SEVERITY_CONFIG[notification.category] || SEVERITY_CONFIG.info;
   const timeAgo = formatDistanceToNow(new Date(notification.created_at), { addSuffix: true });
 
   const handleClick = () => {
@@ -111,7 +225,7 @@ function NotificationItem({ notification, onMarkRead, onDelete, onViewDetail }) 
       className={`d-flex align-items-start gap-2 px-3 py-2 notification-item ${!notification.is_read ? 'notification-item--unread' : ''} ${notification.has_detail ? 'notification-item--expandable' : ''}`}
       onClick={handleClick}
     >
-      <i className={`bi ${icon} mt-1`} />
+      <span className={`notification-severity-dot ${config.dotClass} mt-1 flex-shrink-0`} />
       <div className="flex-grow-1" style={{ minWidth: 0 }}>
         <div className="d-flex justify-content-between align-items-start">
           <strong className={`small notification-title ${!notification.is_read ? '' : 'fw-normal'}`}>

--- a/services/ui/src/components/toolbar/Toolbar.jsx
+++ b/services/ui/src/components/toolbar/Toolbar.jsx
@@ -19,6 +19,7 @@ import usePresence from "@/hooks/ui/usePresence";
 import NotificationDropdown from "@/components/toolbar/NotificationDropdown";
 import NotificationDetailModal from "@/components/toolbar/NotificationDetailModal";
 import useNotifications from "@/hooks/ui/useNotifications";
+import usePopOutPreview from "@/hooks/ui/usePopOutPreview";
 
 function Toolbar({
   fullscreenPreview,
@@ -28,11 +29,12 @@ function Toolbar({
   setShowIconBrowser
 }) {
   const { theme, setTheme } = useTheme();
-  const { currentDocument, error: _error, isSharedView, sharedDocument, sharedLoading, sharedError: _sharedError, previewHTML: _previewHTML, setShowChatDrawer, categories, saveDocument, renameDocument, content, mobileViewMode, setMobileViewMode, loadDocument } = useDocumentContext();
+  const { currentDocument, error: _error, isSharedView, sharedDocument, sharedLoading, sharedError: _sharedError, previewHTML, setShowChatDrawer, categories, saveDocument, renameDocument, content, mobileViewMode, setMobileViewMode, loadDocument } = useDocumentContext();
   const { showWarning: _showWarning } = useNotification();
   const { user } = useAuth();
   const { isMobile } = useViewport();
   const { users: presenceUsers } = usePresence(currentDocument?.id || null);
+  const { openPopOut } = usePopOutPreview();
   const { notifications: notifList, unreadCount, markRead, markAllRead, deleteNotification, clearAll, fetchNotificationDetail } = useNotifications();
   const [documentTitle, setDocumentTitleState] = useState(
     currentDocument?.name || "Untitled Document"
@@ -265,6 +267,24 @@ function Toolbar({
               onDelete={deleteNotification}
               onClearAll={clearAll}
               onViewDetail={handleViewNotificationDetail}
+            />
+          )}
+          {!isSharedView && (
+            <ActionButton
+              id="popOutBtn"
+              variant="outline-secondary"
+              size="sm"
+              title="Open preview in new window"
+              disabled={!currentDocument?.id}
+              onClick={(e) => {
+                e.preventDefault();
+                openPopOut(
+                  currentDocument?.name || 'Untitled Document',
+                  previewHTML,
+                  theme
+                );
+              }}
+              icon="bi bi-box-arrow-up-right"
             />
           )}
           <ActionButton

--- a/services/ui/src/components/toolbar/Toolbar.jsx
+++ b/services/ui/src/components/toolbar/Toolbar.jsx
@@ -34,7 +34,10 @@ function Toolbar({
   const { user } = useAuth();
   const { isMobile } = useViewport();
   const { users: presenceUsers } = usePresence(currentDocument?.id || null);
-  const { openPopOut } = usePopOutPreview();
+  const { openPopOut } = usePopOutPreview({
+    previewHTML,
+    documentTitle: currentDocument?.name || 'Untitled Document',
+  });
   const { notifications: notifList, unreadCount, markRead, markAllRead, deleteNotification, clearAll, fetchNotificationDetail } = useNotifications();
   const [documentTitle, setDocumentTitleState] = useState(
     currentDocument?.name || "Untitled Document"
@@ -278,11 +281,7 @@ function Toolbar({
               disabled={!currentDocument?.id}
               onClick={(e) => {
                 e.preventDefault();
-                openPopOut(
-                  currentDocument?.name || 'Untitled Document',
-                  previewHTML,
-                  theme
-                );
+                openPopOut(theme);
               }}
               icon="bi bi-box-arrow-up-right"
             />

--- a/services/ui/src/hooks/document/useDocumentState.js
+++ b/services/ui/src/hooks/document/useDocumentState.js
@@ -499,7 +499,10 @@ export default function useDocumentState(notification, auth, setPreviewHTML, isS
 
       // Guard: only write back to state if the user is still viewing the document
       // that was saved. A slow-resolving save should not overwrite a freshly loaded doc.
-      const isStillCurrentDocument = saved.id === currentDocumentIdRef.current;
+      // Also match when the original doc ID was a temporary doc_ ID that the backend
+      // replaced with a permanent ID (e.g. first save / category change on a new doc).
+      const isStillCurrentDocument = saved.id === currentDocumentIdRef.current
+        || docToSave.id === currentDocumentIdRef.current;
 
       if (documentChanged && isStillCurrentDocument) {
         setCurrentDocument(saved);
@@ -568,7 +571,10 @@ export default function useDocumentState(notification, auth, setPreviewHTML, isS
   const renameDocument = useCallback(async (id, newName, newCategory = DEFAULT_CATEGORY) => {
     try {
       const doc = DocumentService.loadDocument(id);
-      if (!doc) return;
+      if (!doc) {
+        showError('Cannot rename: document not found. Try saving first.');
+        return;
+      }
       const updatedDoc = { ...doc, name: newName, category: newCategory };
       const saved = await DocumentService.saveDocument(updatedDoc, false);
       const docs = DocumentService.getAllDocuments();

--- a/services/ui/src/hooks/editor/useGlobalKeyboardShortcuts.js
+++ b/services/ui/src/hooks/editor/useGlobalKeyboardShortcuts.js
@@ -7,17 +7,15 @@ import { useSaveDocument } from '../document';
  * 
  * Currently handles:
  * - Ctrl+S (Cmd+S on Mac): Save document
- * 
- * Future shortcuts can be added here:
- * - Ctrl+N: New document
- * - Ctrl+O: Open document
- * - etc.
+ * - Ctrl+Alt+N (Cmd+Alt+N on Mac): New document
  */
-export default function useGlobalKeyboardShortcuts({ onDraftPromote } = {}) {
+export default function useGlobalKeyboardShortcuts({ onDraftPromote, onNewDocument } = {}) {
   const handleSave = useSaveDocument({ onDraftPromote });
   const handleSaveRef = useRef(handleSave);
-  // Always keep ref up to date with latest handleSave
+  const onNewDocumentRef = useRef(onNewDocument);
+  // Always keep refs up to date with latest callbacks
   handleSaveRef.current = handleSave;
+  onNewDocumentRef.current = onNewDocument;
 
   useEffect(() => {
     const handleGlobalKeyDown = async (e) => {
@@ -26,17 +24,11 @@ export default function useGlobalKeyboardShortcuts({ onDraftPromote } = {}) {
         e.preventDefault();
         await handleSaveRef.current();
       }
-      // Future global shortcuts can be added here:
-      /*
-      if ((e.ctrlKey || e.metaKey) && e.key === 'n') {
+      // Ctrl+Alt+N (or Cmd+Alt+N on Mac) - New document
+      if ((e.ctrlKey || e.metaKey) && e.altKey && e.key === 'n') {
         e.preventDefault();
-        // Handle new document
+        onNewDocumentRef.current?.();
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === 'o') {
-        e.preventDefault();
-        // Handle open document
-      }
-      */
     };
     document.addEventListener('keydown', handleGlobalKeyDown);
     return () => {

--- a/services/ui/src/hooks/ui/index.js
+++ b/services/ui/src/hooks/ui/index.js
@@ -9,3 +9,4 @@ export { default as useFileModal } from './useFileModal';
 export { useCodeCopy } from './useCodeCopy';
 export { default as useResponsiveMenu } from './useResponsiveMenu';
 export { useViewport } from './useViewport';
+export { default as usePopOutPreview } from './usePopOutPreview';

--- a/services/ui/src/hooks/ui/useNotifications.js
+++ b/services/ui/src/hooks/ui/useNotifications.js
@@ -103,8 +103,13 @@ export default function useNotifications() {
     fetchNotifications();
     pollRef.current = setInterval(fetchNotifications, POLL_INTERVAL);
 
+    // Listen for toast-bridge events to refresh immediately
+    const handleCreated = () => fetchNotifications();
+    window.addEventListener('notification-created', handleCreated);
+
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
+      window.removeEventListener('notification-created', handleCreated);
     };
   }, [isAuthenticated, fetchNotifications]);
 

--- a/services/ui/src/hooks/ui/usePopOutPreview.js
+++ b/services/ui/src/hooks/ui/usePopOutPreview.js
@@ -1,0 +1,133 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Hook to manage pop-out read-only preview windows.
+ * Opens a child window with a frozen snapshot of the rendered document.
+ * All child windows close automatically when the parent window closes.
+ */
+export default function usePopOutPreview() {
+  const childWindowsRef = useRef(new Set());
+
+  // Clean up closed windows from the set periodically
+  const pruneClosedWindows = useCallback(() => {
+    for (const win of childWindowsRef.current) {
+      if (win.closed) {
+        childWindowsRef.current.delete(win);
+      }
+    }
+  }, []);
+
+  // Close all child windows on parent unload
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      for (const win of childWindowsRef.current) {
+        try {
+          if (!win.closed) win.close();
+        } catch (_e) {
+          // Cross-origin or already closed — ignore
+        }
+      }
+      childWindowsRef.current.clear();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      handleBeforeUnload();
+    };
+  }, []);
+
+  const openPopOut = useCallback((title, renderedHTML, theme) => {
+    pruneClosedWindows();
+
+    const child = window.open('', '', 'width=900,height=700,scrollbars=yes,resizable=yes');
+    if (!child) return; // Popup blocked
+
+    childWindowsRef.current.add(child);
+
+    // Collect parent stylesheets to replicate in the child window
+    const stylesheetLinks = Array.from(document.querySelectorAll('link[rel="stylesheet"]'))
+      .map(link => `<link rel="stylesheet" href="${link.href}" />`)
+      .join('\n');
+
+    const escapedTitle = title
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+
+    const html = `<!DOCTYPE html>
+<html data-bs-theme="${theme === 'dark' ? 'dark' : 'light'}">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapedTitle} — Read-only Preview</title>
+  ${stylesheetLinks}
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    .popout-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-bottom: 1px solid var(--mm-border, #dee2e6);
+      background: var(--mm-bg-surface, #f8f9fa);
+      flex-shrink: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    }
+    .popout-header .doc-title {
+      font-weight: 600;
+      font-size: 14px;
+      color: var(--mm-text, #212529);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .popout-header .badge {
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      background: var(--mm-primary, #4f6df5);
+      color: #fff;
+      font-weight: 500;
+      flex-shrink: 0;
+    }
+    .popout-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px 32px;
+    }
+  </style>
+</head>
+<body>
+  <div class="popout-header">
+    <i class="bi bi-file-earmark-text" style="font-size:16px;color:var(--mm-text-secondary,#6c757d)"></i>
+    <span class="doc-title">${escapedTitle}</span>
+    <span class="badge">
+      <i class="bi bi-eye" style="margin-right:4px"></i>Read-only
+    </span>
+  </div>
+  <div class="popout-body">
+    <div class="preview-content">${renderedHTML || ''}</div>
+  </div>
+</body>
+</html>`;
+
+    child.document.open();
+    child.document.write(html);
+    child.document.close();
+
+    // Remove from tracking set when child is closed by user
+    child.addEventListener('beforeunload', () => {
+      childWindowsRef.current.delete(child);
+    });
+  }, [pruneClosedWindows]);
+
+  return { openPopOut };
+}

--- a/services/ui/src/hooks/ui/usePopOutPreview.js
+++ b/services/ui/src/hooks/ui/usePopOutPreview.js
@@ -2,13 +2,14 @@ import { useRef, useEffect, useCallback } from 'react';
 
 /**
  * Hook to manage pop-out read-only preview windows.
- * Opens a child window with a frozen snapshot of the rendered document.
+ * Opens a child window showing the rendered document preview.
+ * Live-syncs previewHTML and document title to all open child windows.
  * All child windows close automatically when the parent window closes.
  */
-export default function usePopOutPreview() {
+export default function usePopOutPreview({ previewHTML, documentTitle } = {}) {
   const childWindowsRef = useRef(new Set());
 
-  // Clean up closed windows from the set periodically
+  // Clean up closed windows from the set
   const pruneClosedWindows = useCallback(() => {
     for (const win of childWindowsRef.current) {
       if (win.closed) {
@@ -37,7 +38,38 @@ export default function usePopOutPreview() {
     };
   }, []);
 
-  const openPopOut = useCallback((title, renderedHTML, theme) => {
+  // Live-sync previewHTML to all open child windows
+  useEffect(() => {
+    if (previewHTML == null) return;
+    pruneClosedWindows();
+    for (const win of childWindowsRef.current) {
+      try {
+        if (win.closed) continue;
+        const el = win.document.querySelector('.preview-content');
+        if (el) el.innerHTML = previewHTML;
+      } catch (_e) {
+        // Window closed or inaccessible — ignore
+      }
+    }
+  }, [previewHTML, pruneClosedWindows]);
+
+  // Live-sync document title to all open child windows
+  useEffect(() => {
+    if (!documentTitle) return;
+    pruneClosedWindows();
+    for (const win of childWindowsRef.current) {
+      try {
+        if (win.closed) continue;
+        const titleEl = win.document.querySelector('.doc-title');
+        if (titleEl) titleEl.textContent = documentTitle;
+        win.document.title = `${documentTitle} — Read-only Preview`;
+      } catch (_e) {
+        // Window closed or inaccessible — ignore
+      }
+    }
+  }, [documentTitle, pruneClosedWindows]);
+
+  const openPopOut = useCallback((theme) => {
     pruneClosedWindows();
 
     const child = window.open('', '', 'width=900,height=700,scrollbars=yes,resizable=yes');
@@ -50,6 +82,7 @@ export default function usePopOutPreview() {
       .map(link => `<link rel="stylesheet" href="${link.href}" />`)
       .join('\n');
 
+    const title = documentTitle || 'Untitled Document';
     const escapedTitle = title
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
@@ -114,7 +147,7 @@ export default function usePopOutPreview() {
     </span>
   </div>
   <div class="popout-body">
-    <div class="preview-content">${renderedHTML || ''}</div>
+    <div class="preview-content">${previewHTML || ''}</div>
   </div>
 </body>
 </html>`;
@@ -127,7 +160,7 @@ export default function usePopOutPreview() {
     child.addEventListener('beforeunload', () => {
       childWindowsRef.current.delete(child);
     });
-  }, [pruneClosedWindows]);
+  }, [pruneClosedWindows, previewHTML, documentTitle]);
 
   return { openPopOut };
 }

--- a/services/ui/src/styles/_base.scss
+++ b/services/ui/src/styles/_base.scss
@@ -232,51 +232,114 @@ select:focus-visible {
   letter-spacing: 0.025em;
 }
 
-// Toast container styles — brief confirmations (important toasts now persist to notification drawer)
-.toast-container {
-  // Position in top center to avoid overlap with side drawers (chat, notifications)
-  top: 80px !important;
-  left: 50% !important;
+// Snackbar container — compact transient notifications (important ones persist to notification drawer)
+.snackbar-container {
+  position: fixed;
+  top: 70px;
+  left: 50%;
   transform: translateX(-50%);
-  bottom: auto !important;
-  right: auto !important;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+  width: auto;
+  max-width: 90vw;
+}
 
-  // Ensure toasts stack properly (newest on top)
-  .toast {
-    margin-bottom: 0.5rem;
-    min-width: 320px;
+.snackbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 300px;
+  max-width: 480px;
+  padding: 0.625rem 0.75rem;
+  background-color: var(--mm-bg-elevated);
+  border: 1px solid var(--mm-border);
+  border-radius: var(--mm-radius-md);
+  box-shadow: var(--mm-shadow-md);
+  color: var(--mm-text);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  pointer-events: auto;
+  overflow: hidden;
+  position: relative;
+  animation: snackbarIn 0.25s ease-out;
 
-    // Smooth animations for showing/hiding
-    &.show {
-      animation: slideInDown 0.25s ease-out;
+  &-accent {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    border-radius: var(--mm-radius-md) 0 0 var(--mm-radius-md);
+  }
+
+  &-icon {
+    flex-shrink: 0;
+    font-size: 1rem;
+    margin-left: 0.25rem;
+  }
+
+  &-message {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  &-dismiss {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: transparent;
+    color: var(--mm-text-secondary);
+    border-radius: var(--mm-radius-sm);
+    cursor: pointer;
+    padding: 0;
+    font-size: 1rem;
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover {
+      background-color: var(--mm-bg-surface);
+      color: var(--mm-text);
     }
+  }
 
-    &.hide {
-      animation: slideOutUp 0.2s ease-in;
-    }
+  // Severity variants — colored accent bar + icon color
+  &--success {
+    .snackbar-accent { background-color: #10b981; }
+    .snackbar-icon { color: #10b981; }
+  }
+
+  &--error {
+    .snackbar-accent { background-color: #ef4444; }
+    .snackbar-icon { color: #ef4444; }
+  }
+
+  &--warning {
+    .snackbar-accent { background-color: #f59e0b; }
+    .snackbar-icon { color: #f59e0b; }
+  }
+
+  &--info {
+    .snackbar-accent { background-color: #3b82f6; }
+    .snackbar-icon { color: #3b82f6; }
   }
 }
 
-// Toast animation keyframes
-@keyframes slideInDown {
+// Snackbar animation keyframes
+@keyframes snackbarIn {
   from {
-    transform: translateY(-100%);
+    transform: translateY(-12px);
     opacity: 0;
   }
   to {
     transform: translateY(0);
     opacity: 1;
-  }
-}
-
-@keyframes slideOutUp {
-  from {
-    transform: translateY(0);
-    opacity: 1;
-  }
-  to {
-    transform: translateY(-100%);
-    opacity: 0;
   }
 }
 

--- a/services/ui/src/styles/_base.scss
+++ b/services/ui/src/styles/_base.scss
@@ -232,47 +232,50 @@ select:focus-visible {
   letter-spacing: 0.025em;
 }
 
-// Toast container styles
+// Toast container styles — brief confirmations (important toasts now persist to notification drawer)
 .toast-container {
-  // Position in bottom right corner
-  bottom: 20px !important;
-  right: 20px !important;
+  // Position in top center to avoid overlap with side drawers (chat, notifications)
+  top: 80px !important;
+  left: 50% !important;
+  transform: translateX(-50%);
+  bottom: auto !important;
+  right: auto !important;
 
   // Ensure toasts stack properly (newest on top)
   .toast {
     margin-bottom: 0.5rem;
-    min-width: 350px;
+    min-width: 320px;
 
     // Smooth animations for showing/hiding
     &.show {
-      animation: slideInRight 0.3s ease-out;
+      animation: slideInDown 0.25s ease-out;
     }
 
     &.hide {
-      animation: slideOutRight 0.3s ease-in;
+      animation: slideOutUp 0.2s ease-in;
     }
   }
 }
 
 // Toast animation keyframes
-@keyframes slideInRight {
+@keyframes slideInDown {
   from {
-    transform: translateX(100%);
+    transform: translateY(-100%);
     opacity: 0;
   }
   to {
-    transform: translateX(0);
+    transform: translateY(0);
     opacity: 1;
   }
 }
 
-@keyframes slideOutRight {
+@keyframes slideOutUp {
   from {
-    transform: translateX(0);
+    transform: translateY(0);
     opacity: 1;
   }
   to {
-    transform: translateX(100%);
+    transform: translateY(-100%);
     opacity: 0;
   }
 }

--- a/services/ui/src/styles/toolbar/_notifications.scss
+++ b/services/ui/src/styles/toolbar/_notifications.scss
@@ -1,9 +1,10 @@
-// Notification Dropdown Styles
-// Dark-theme-aware styling for the notification dropdown
+// Notification Drawer & Severity Styles
+// Dark-theme-aware styling for the notification dropdown and drawer
 
 @use "../variables";
 @use "../mixins";
 
+// ─── Legacy dropdown (kept for backward compat) ───
 .notification-dropdown-menu {
   width: 340px;
   max-height: 400px;
@@ -310,4 +311,121 @@
     font-weight: variables.$font-weight-bold;
     color: var(--mm-text);
   }
+}
+
+// ─── NOTIFICATION DRAWER (Offcanvas) ───
+
+.notification-drawer {
+  &.offcanvas.offcanvas-start {
+    width: 380px;
+    max-width: 90vw;
+    background: var(--mm-bg-elevated);
+    border-right: 1px solid var(--mm-border);
+    color: var(--mm-text);
+
+    @include mixins.mobile {
+      width: 100vw;
+      max-width: 100vw;
+      border-right: none;
+    }
+  }
+}
+
+.notification-drawer-header {
+  border-bottom: 1px solid var(--mm-border);
+  padding: variables.$space-3 variables.$space-4;
+
+  .btn-close {
+    filter: var(--mm-btn-close-filter, none);
+  }
+}
+
+.notification-drawer-title {
+  font-size: variables.$font-size-md;
+  font-weight: variables.$font-weight-semibold;
+  display: flex;
+  align-items: center;
+
+  .bi-bell {
+    color: var(--mm-primary);
+  }
+}
+
+.notification-drawer-controls {
+  border-bottom: 1px solid var(--mm-border);
+  background-color: var(--mm-bg-surface);
+}
+
+.notification-unread-toggle {
+  font-size: variables.$font-size-sm;
+  color: var(--mm-text-secondary);
+}
+
+.notification-drawer-body {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+// ─── SEVERITY DOTS ───
+
+.notification-severity-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: variables.$radius-full;
+  flex-shrink: 0;
+
+  &--error {
+    background-color: variables.$color-danger;
+  }
+
+  &--warning {
+    background-color: variables.$color-warning;
+  }
+
+  &--info {
+    background-color: variables.$color-info;
+  }
+
+  &--success {
+    background-color: variables.$color-success;
+  }
+}
+
+// ─── SEVERITY GROUP SECTIONS ───
+
+.notification-group-divider {
+  height: 3px;
+  border: none;
+  margin: 0;
+
+  &--error {
+    background: linear-gradient(90deg, variables.$color-danger, transparent);
+  }
+
+  &--warning {
+    background: linear-gradient(90deg, variables.$color-warning, transparent);
+  }
+
+  &--info {
+    background: linear-gradient(90deg, variables.$color-info, transparent);
+  }
+
+  &--success {
+    background: linear-gradient(90deg, variables.$color-success, transparent);
+  }
+}
+
+.notification-group-heading {
+  font-size: variables.$font-size-sm;
+  font-weight: variables.$font-weight-semibold;
+  color: var(--mm-text-secondary);
+  display: flex;
+  align-items: center;
+  background-color: var(--mm-bg-surface);
+
+  .bi-x-circle { color: variables.$color-danger; }
+  .bi-exclamation-triangle { color: variables.$color-warning; }
+  .bi-info-circle { color: variables.$color-info; }
+  .bi-check-circle { color: variables.$color-success; }
 }


### PR DESCRIPTION
## Summary

Replace the intrusive bottom-right Bootstrap toasts with a two-tier notification system: compact snackbars for transient feedback + a persistent slide-out notification drawer for history.

## Changes

### Notification Drawer (new)
- Converted `NotificationDropdown` from a small `Dropdown` to a full `Offcanvas` slide-out drawer (opens from left to avoid chat drawer conflict)
- Severity-colored dots on each notification item (error=red, warning=amber, info=blue, success=green)
- **Timeline / By Severity** view toggle with `localStorage` persistence
- Severity-grouped view with colored `<hr>` dividers and group headings with count badges
- **Unread Only** filter toggle
- Bell badge color reflects highest-severity unread notification
- Mobile: full-width drawer

### Toast → Snackbar Redesign
- Replaced Bootstrap `<Toast>` with compact custom snackbar component
- Uses app design tokens: `--mm-bg-elevated` surface, `--mm-border`, `--mm-shadow-md`, `--mm-radius-md`
- 3px colored left accent bar + severity-colored icon (no flat color fills)
- Single-line layout: `[accent] [icon] message [× dismiss]`
- Repositioned to top-center to avoid side drawer overlap
- Shortened auto-dismiss: 3s success/info, 5s warning/error

### Toast → Notification Bridge
- Warning/error toasts automatically persist to the notification drawer via `POST /notifications`
- Callers can override with `{ persist: true/false }` option
- Success/info remain transient-only (no "Copied!" clutter)
- `notification-created` event triggers immediate drawer refresh (no 60s poll wait)
- Fixed detail serialization bug: object-typed `details` now `JSON.stringify()`d before POST

### Error Detail Enrichment
- Global error handler (`api.js`) now passes backend endpoint, status, and error detail into notification events
- Persisted notifications include full error context (endpoint, HTTP status, backend detail message)

### Bug Fix
- Fixed `GET /admin/github/users` 500: missing `recents_tab_limit` field in `UserResponse` constructor

## Files Changed
- `services/ui/src/components/NotificationProvider.jsx` — snackbar + bridge + detail serialization
- `services/ui/src/components/toolbar/NotificationDropdown.jsx` — Offcanvas drawer rewrite
- `services/ui/src/hooks/ui/useNotifications.js` — notification-created event listener
- `services/ui/src/api/notificationsApi.js` — added `create()` method
- `services/ui/src/api/api.js` — enriched error notification events
- `services/ui/src/styles/_base.scss` — snackbar CSS with app design tokens
- `services/ui/src/styles/toolbar/_notifications.scss` — drawer + severity dot + group styles
- `services/backend/app/routers/admin/github.py` — added missing recents_tab_limit

## No Backend Schema Changes
Existing `Notification.category` field (info/success/warning/error) and `POST /notifications` endpoint required zero backend modifications.