### PR TITLE
feat: cross-app SSO, chat improvements, PG18 upgrade, and GitHub Models support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
 SECURE_COOKIES=false
 
+# Cross-app SSO (shared with team-manager)
+SSO_SECRET_KEY=dev-sso-shared-secret-change-in-production
+SSO_TOKEN_EXPIRE_DAYS=1
+SSO_COOKIE_DOMAIN=
+
 # Storage Configuration
 MARKDOWN_STORAGE_ROOT=/documents
 CONTAINER_STORAGE_ROOT=/documents

--- a/deployment/production.env.template
+++ b/deployment/production.env.template
@@ -27,6 +27,13 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 SECURE_COOKIES=true
 
+# ── Cross-App SSO ────────────────────────────────────────────────────────────
+# Shared secret between markdown-manager and team-manager for SSO cookies.
+# Must be identical in both apps. Generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
+SSO_SECRET_KEY=CHANGE_ME_MUST_MATCH_OTHER_APP
+SSO_TOKEN_EXPIRE_DAYS=1
+SSO_COOKIE_DOMAIN=.littledan.com
+
 # ── CORS ─────────────────────────────────────────────────────────────────────
 ALLOWED_ORIGINS=https://yourdomain.com
 

--- a/deployment/roles/app_deploy/tasks/main.yml
+++ b/deployment/roles/app_deploy/tasks/main.yml
@@ -62,17 +62,6 @@
   delay: 2
   until: db_health.rc == 0
 
-- name: Refresh database collation version
-  command: >
-    docker compose -p mm-infra -f docker-compose.infra.yml --env-file deployment/production.env exec -T db
-    psql -U {{ postgres_user | default('markdown_manager') }} -d {{ postgres_db | default('markdown_manager') }}
-    -c "ALTER DATABASE {{ postgres_db | default('markdown_manager') }} REFRESH COLLATION VERSION;"
-  args:
-    chdir: "{{ app_dir }}"
-  register: collation_result
-  changed_when: "'ALTER DATABASE' in collation_result.stdout"
-  failed_when: false
-
 - name: Run blue/green deployment
   command: "{{ app_dir }}/scripts/deploy-blue-green.sh {{ deploy_flags | default('') }}"
   args:

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -129,12 +129,15 @@ services:
       context: ./services/embedding
       dockerfile: Dockerfile
     restart: unless-stopped
+    volumes:
+      - hf-cache:/root/.cache/huggingface
+      - onnx-cache:/embedding/.onnx_cache
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8005/health"]
       interval: 30s
       timeout: 30s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 300s
     deploy:
       resources:
         limits:
@@ -323,6 +326,10 @@ volumes:
   ui-static:
     # Project-scoped: each blue/green stack gets its own UI volume
     # Named mm-blue-ui-static or mm-green-ui-static by Docker Compose
+  hf-cache:
+    name: mm-hf-cache
+  onnx-cache:
+    name: mm-onnx-cache
   document-storage:
     name: mm-document-storage
     external: true

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -43,14 +43,14 @@ services:
   # PostgreSQL
   # ──────────────────────────────────────────────────────────────────────────
   db:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg18
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-markdown_manager}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: ${POSTGRES_DB:-markdown_manager}
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-markdown_manager} -d ${POSTGRES_DB:-markdown_manager}"]
       interval: 5s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,6 +70,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-markdown_manager}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: ${POSTGRES_DB:-markdown_manager}
+    env_file:
+      - ./deployment/production.env
     volumes:
       - postgres-data:/var/lib/postgresql
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,14 +64,14 @@ services:
   # PostgreSQL
   # ──────────────────────────────────────────────────────────────────────────
   db:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg18
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-markdown_manager}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: ${POSTGRES_DB:-markdown_manager}
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-markdown_manager} -d ${POSTGRES_DB:-markdown_manager}"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     init: true
 
   db:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg18
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
@@ -46,7 +46,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./services/backend/postgres-data:/var/lib/postgresql/data
+      - ./services/backend/postgres-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres -d markdown_manager || exit 1"]
       interval: 5s

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -32,7 +32,7 @@ SLOT_FILE="${APP_DIR}/.deploy-slot"
 STOP_TIMEOUT=30          # Grace period for in-flight requests (seconds)
 HEALTH_RETRIES=30        # Max health check attempts
 HEALTH_DELAY=5           # Seconds between health checks
-BACKEND_HEALTH_RETRIES=40
+BACKEND_HEALTH_RETRIES=60  # 300s budget for embedding ONNX init
 BACKEND_HEALTH_DELAY=5
 
 # ── Flags ────────────────────────────────────────────────────────────────────

--- a/scripts/deploy-infra.sh
+++ b/scripts/deploy-infra.sh
@@ -40,7 +40,7 @@ docker network inspect mm-network >/dev/null 2>&1 || \
   docker network create --driver bridge mm-network
 
 # Create the shared document-storage volume if it doesn't exist
-for vol in mm-document-storage mm-postgres-data mm-redis-data mm-ollama-data mm-clamav-data; do
+for vol in mm-document-storage mm-postgres-data mm-redis-data mm-ollama-data mm-clamav-data mm-hf-cache mm-onnx-cache; do
   docker volume inspect "$vol" >/dev/null 2>&1 || docker volume create "$vol"
 done
 

--- a/services/backend/app/configs/settings.py
+++ b/services/backend/app/configs/settings.py
@@ -57,6 +57,20 @@ class Settings(BaseSettings):
         default=False, description="Use secure cookies (HTTPS only)"
     )
 
+    # Cross-app SSO
+    sso_secret_key: str = Field(
+        default="", description="Shared secret key for cross-app SSO tokens"
+    )
+    sso_token_expire_days: int = Field(
+        default=1, description="SSO token expiration in days"
+    )
+    sso_cookie_domain: str = Field(
+        default=".littledan.com", description="Domain for SSO cookie"
+    )
+    app_identifier: str = Field(
+        default="markdown-manager", description="App identifier for JWT iss/aud claims"
+    )
+
     # SMTP configuration
     smtp_host: str = Field(default="smtp.example.com", description="SMTP server host")
     smtp_port: int = Field(

--- a/services/backend/app/core/auth.py
+++ b/services/backend/app/core/auth.py
@@ -1,4 +1,5 @@
 """Authentication utilities."""
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -46,11 +47,62 @@ def create_access_token(
         expire = datetime.now(timezone.utc) + timedelta(
             minutes=settings.access_token_expire_minutes
         )
-    to_encode.update({"exp": expire})
+    to_encode.update({
+        "exp": expire,
+        "iss": settings.app_identifier,
+        "aud": settings.app_identifier,
+    })
     encoded_jwt = jwt.encode(
         to_encode, settings.secret_key, algorithm=settings.algorithm
     )
     return str(encoded_jwt)
+
+
+# ── Cross-app SSO token functions ────────────────────────────────────────────
+
+
+@dataclass
+class SSOTokenData:
+    email: str
+    issuer: str
+    mfa_verified: bool
+
+
+def create_sso_token(email: str, mfa_verified: bool = False) -> str:
+    """Create a cross-app SSO token signed with the shared SSO secret."""
+    expire = datetime.now(timezone.utc) + timedelta(days=settings.sso_token_expire_days)
+    payload = {
+        "sub": email,
+        "iss": settings.app_identifier,
+        "aud": "sso",
+        "exp": expire,
+        "iat": datetime.now(timezone.utc),
+        "mfa_verified": mfa_verified,
+    }
+    return jwt.encode(payload, settings.sso_secret_key, algorithm=settings.algorithm)
+
+
+def validate_sso_token(token: str) -> Optional[SSOTokenData]:
+    """Validate a cross-app SSO token. Returns SSOTokenData or None."""
+    if not settings.sso_secret_key:
+        return None
+    try:
+        payload = jwt.decode(
+            token,
+            settings.sso_secret_key,
+            algorithms=[settings.algorithm],
+            audience="sso",
+        )
+        email = payload.get("sub")
+        if not email:
+            return None
+        return SSOTokenData(
+            email=email,
+            issuer=payload.get("iss", ""),
+            mfa_verified=payload.get("mfa_verified", False),
+        )
+    except jwt.InvalidTokenError:
+        return None
 
 
 async def get_user_by_email(db: AsyncSession, email: str) -> Optional[User]:
@@ -91,6 +143,7 @@ async def get_current_user(
             credentials.credentials,
             settings.secret_key,
             algorithms=[settings.algorithm],
+            audience=settings.app_identifier,
         )
         email = payload.get("sub")
         if not isinstance(email, str) or not email:
@@ -101,7 +154,6 @@ async def get_current_user(
     user = await get_user_by_email(db, email=email)
     if user is None:
         raise credentials_exception
-
     return user
 
 
@@ -118,6 +170,7 @@ async def get_current_user_optional(
             credentials.credentials,
             settings.secret_key,
             algorithms=[settings.algorithm],
+            audience=settings.app_identifier,
         )
         email = payload.get("sub")
         if not isinstance(email, str) or not email:

--- a/services/backend/app/crud/user_api_key.py
+++ b/services/backend/app/crud/user_api_key.py
@@ -51,6 +51,7 @@ async def create_key(
     label: str | None = None,
     base_url: str | None = None,
     preferred_model: str | None = None,
+    org_name: str | None = None,
 ) -> UserApiKey:
     """Create a new encrypted API key record."""
     secret = get_settings().secret_key
@@ -61,6 +62,7 @@ async def create_key(
         label=label,
         base_url=base_url,
         preferred_model=preferred_model,
+        org_name=org_name,
         is_active=True,
     )
     db.add(row)
@@ -77,6 +79,7 @@ async def update_key(
     label: str | None = ...,  # type: ignore[assignment]
     base_url: str | None = ...,  # type: ignore[assignment]
     preferred_model: str | None = ...,  # type: ignore[assignment]
+    org_name: str | None = ...,  # type: ignore[assignment]
     is_active: bool | None = None,
     api_key: str | None = None,
 ) -> UserApiKey | None:
@@ -91,6 +94,8 @@ async def update_key(
         row.base_url = base_url
     if preferred_model is not ...:
         row.preferred_model = preferred_model
+    if org_name is not ...:
+        row.org_name = org_name
     if is_active is not None:
         row.is_active = is_active
     if api_key is not None:

--- a/services/backend/app/models/user_api_key.py
+++ b/services/backend/app/models/user_api_key.py
@@ -68,4 +68,5 @@ class UserApiKey(BaseModel):
     label: Mapped[str | None] = mapped_column(String(128), nullable=True)
     base_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
     preferred_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    org_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/services/backend/app/routers/api_keys.py
+++ b/services/backend/app/routers/api_keys.py
@@ -46,6 +46,7 @@ async def add_key(
         label=body.label,
         base_url=body.base_url,
         preferred_model=body.preferred_model,
+        org_name=body.org_name,
     )
     return ApiKeyResponse.model_validate(row)
 
@@ -65,6 +66,8 @@ async def update_key(
         kwargs["base_url"] = body.base_url
     if body.preferred_model is not None:
         kwargs["preferred_model"] = body.preferred_model
+    if body.org_name is not None:
+        kwargs["org_name"] = body.org_name
     if body.is_active is not None:
         kwargs["is_active"] = body.is_active
     if body.api_key is not None:
@@ -106,6 +109,7 @@ async def test_key(
             api_key=api_key,
             model=row.preferred_model,
             base_url=row.base_url,
+            org_name=row.org_name,
         )
         ok = await provider.health_check()
     except Exception as exc:
@@ -133,6 +137,7 @@ async def list_models(
             api_key=api_key,
             model=row.preferred_model,
             base_url=row.base_url,
+            org_name=row.org_name,
         )
         models = await provider.list_models()
     except Exception as exc:

--- a/services/backend/app/routers/auth/login.py
+++ b/services/backend/app/routers/auth/login.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.configs import settings
 from app.configs.environment import environment_config
-from app.core.auth import authenticate_user, create_access_token
+from app.core.auth import authenticate_user, create_access_token, create_sso_token
 from app.core.mfa import verify_backup_code, verify_totp_code
 from app.crud import user as crud_user
 from app.crud.github_crud import GitHubCRUD
@@ -20,6 +20,34 @@ from app.services.github_service import GitHubService
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+SSO_COOKIE = "sso_token"
+SSO_MAX_AGE = settings.sso_token_expire_days * 86400 if hasattr(settings, 'sso_token_expire_days') else 86400
+
+
+def _set_sso_cookie(response: Response, token: str) -> None:
+    """Set the cross-app SSO cookie on the shared domain."""
+    if not settings.sso_secret_key:
+        return
+    response.set_cookie(
+        key=SSO_COOKIE,
+        value=token,
+        httponly=True,
+        secure=settings.secure_cookies,
+        samesite="lax",
+        max_age=SSO_MAX_AGE,
+        path="/",
+        domain=settings.sso_cookie_domain if settings.secure_cookies else None,
+    )
+
+
+def _clear_sso_cookie(response: Response) -> None:
+    """Clear the cross-app SSO cookie."""
+    response.delete_cookie(
+        SSO_COOKIE,
+        path="/",
+        domain=settings.sso_cookie_domain if settings.secure_cookies else None,
+    )
 
 
 async def should_sync_account(account, force_sync: bool) -> bool:
@@ -160,6 +188,7 @@ async def login(
         path="/",
         domain=environment_config.get_cookie_domain(),
     )
+    _set_sso_cookie(response, create_sso_token(user.email, mfa_verified=False))
 
     # Start background task to sync GitHub repositories
     background_tasks.add_task(
@@ -251,6 +280,7 @@ async def refresh_token(
         path="/",
         domain=environment_config.get_cookie_domain(),
     )
+    _set_sso_cookie(response, create_sso_token(user.email, mfa_verified=user.mfa_enabled))
 
     # Start background task to sync GitHub repositories (respects 1-hour limit)
     background_tasks.add_task(
@@ -341,6 +371,7 @@ async def login_mfa(
         path="/",
         domain=environment_config.get_cookie_domain(),
     )
+    _set_sso_cookie(response, create_sso_token(user.email, mfa_verified=True))
 
     # Start background task to sync GitHub repositories
     background_tasks.add_task(
@@ -376,4 +407,5 @@ async def login_mfa(
 @router.post("/logout")
 async def logout(response: Response):
     response.delete_cookie("refresh_token", path="/", domain=environment_config.get_cookie_domain())
+    _clear_sso_cookie(response)
     return {"message": "Logged out"}

--- a/services/backend/app/routers/auth/router.py
+++ b/services/backend/app/routers/auth/router.py
@@ -1,7 +1,7 @@
 """Main authentication router that aggregates all auth sub-routers."""
 from fastapi import APIRouter
 
-from . import login, mfa, password_reset, profile, registration
+from . import login, mfa, password_reset, profile, registration, sso
 
 router = APIRouter()
 
@@ -11,3 +11,4 @@ router.include_router(registration.router, tags=["registration"])
 router.include_router(profile.router, tags=["profile"])
 router.include_router(password_reset.router, tags=["password-reset"])
 router.include_router(mfa.router, prefix="/mfa", tags=["mfa"])
+router.include_router(sso.router, tags=["sso"])

--- a/services/backend/app/routers/auth/sso.py
+++ b/services/backend/app/routers/auth/sso.py
@@ -1,0 +1,90 @@
+"""Cross-app SSO check endpoint."""
+import logging
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, HTTPException, Request, Response, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.configs import settings
+from app.configs.environment import environment_config
+from app.core.auth import create_access_token, validate_sso_token
+from app.crud import user as crud_user
+from app.database import get_db
+from app.routers.auth.login import create_refresh_token
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+SSO_COOKIE = "sso_token"
+
+
+@router.get("/sso-check")
+async def sso_check(
+    request: Request,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
+    """Check for a valid cross-app SSO cookie and bootstrap a local session."""
+    if not settings.sso_secret_key:
+        raise HTTPException(status_code=404, detail="SSO not configured")
+
+    token = request.cookies.get(SSO_COOKIE)
+    if not token:
+        raise HTTPException(status_code=401, detail="No SSO token")
+
+    sso_data = validate_sso_token(token)
+    if not sso_data:
+        raise HTTPException(status_code=401, detail="Invalid or expired SSO token")
+
+    user = await crud_user.get_user_by_email(db, sso_data.email)
+    if not user:
+        return {"linked": False, "email": sso_data.email, "issuer": sso_data.issuer}
+
+    if not user.is_active:
+        raise HTTPException(status_code=403, detail="Account is disabled")
+
+    # MFA gate: if local user requires MFA but SSO login didn't verify MFA, reject
+    if user.mfa_enabled and not sso_data.mfa_verified:
+        return {"mfa_required": True, "email": sso_data.email}
+
+    # Bootstrap local session
+    access_token_expires = timedelta(minutes=settings.access_token_expire_minutes)
+    access_token = create_access_token(
+        data={"sub": user.email}, expires_delta=access_token_expires
+    )
+    refresh_token_expires = timedelta(days=14)
+    refresh_token = create_refresh_token({"sub": user.email}, refresh_token_expires)
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        secure=settings.secure_cookies,
+        samesite="lax",
+        max_age=14 * 24 * 60 * 60,
+        path="/",
+        domain=environment_config.get_cookie_domain(),
+    )
+
+    # Track last login
+    user.last_login = datetime.utcnow()
+    await db.commit()
+
+    # Load current document content if it exists
+    if user.current_document and user.current_document.file_path:
+        from app.services.storage.user import UserStorage
+        try:
+            storage_service = UserStorage()
+            content = await storage_service.read_document(
+                user_id=user.id,
+                file_path=user.current_document.file_path
+            )
+            user.current_document.content = content or ""
+        except Exception as e:
+            logger.warning(f"Failed to load current document content for user {user.id} (SSO): {e}")
+            user.current_document.content = ""
+
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": user,
+    }

--- a/services/backend/app/routers/chat.py
+++ b/services/backend/app/routers/chat.py
@@ -91,6 +91,7 @@ async def ask(
 
     if request.key_id is not None:
         # Look up the specific key by ID — supports multi-key per provider
+        logger.info("Chat provider resolution: key_id=%s (user=%s)", request.key_id, current_user.id)
         key_row = await get_key_by_id(db, request.key_id, current_user.id)
         if not key_row:
             raise HTTPException(
@@ -112,7 +113,11 @@ async def ask(
         )
         qa = _build_qa_service(llm_provider)
     elif requested_provider in ("openai", "xai", "github", "gemini"):
-        # Look up the user’s stored (encrypted) key for the requested provider
+        # Look up the user's stored (encrypted) key for the requested provider
+        logger.info(
+            "Chat provider resolution: remote provider=%s (user=%s)",
+            requested_provider, current_user.id,
+        )
         key_row = await get_active_key(db, current_user.id, requested_provider)
         if not key_row:
             raise HTTPException(
@@ -130,6 +135,7 @@ async def ask(
         qa = _build_qa_service(llm_provider)
     else:
         # Ollama — honour admin overrides from SiteSetting
+        logger.info("Chat provider resolution: ollama (user=%s, model=%s)", current_user.id, request.model)
         from app.models.site_setting import SiteSetting
         from sqlalchemy import select as _select
         _db_model = await db.scalar(_select(SiteSetting).where(SiteSetting.key == "llm.model"))
@@ -168,7 +174,7 @@ async def ask(
                     # JSON-encode so embedded newlines and special chars survive SSE transport
                     yield f"data: {json.dumps(token)}\n\n"
         except Exception as exc:
-            logger.exception("Error during Q&A streaming")
+            logger.exception("Error during Q&A streaming (provider=%s)", requested_provider)
             # Surface useful detail for known error types
             msg = str(exc) if str(exc) else "An error occurred while generating the answer."
             yield f"data: {json.dumps(f'[ERROR] {msg}')}\n\n"

--- a/services/backend/app/routers/chat.py
+++ b/services/backend/app/routers/chat.py
@@ -110,6 +110,7 @@ async def ask(
             api_key=api_key,
             model=request.model or key_row.preferred_model,
             base_url=key_row.base_url,
+            org_name=key_row.org_name,
         )
         qa = _build_qa_service(llm_provider)
     elif requested_provider in ("openai", "xai", "github", "gemini"):
@@ -131,6 +132,7 @@ async def ask(
             api_key=api_key,
             model=request.model or key_row.preferred_model,
             base_url=key_row.base_url,
+            org_name=key_row.org_name,
         )
         qa = _build_qa_service(llm_provider)
     else:
@@ -169,6 +171,9 @@ async def ask(
                         if k != "__metrics__"
                     }
                     event = {"type": "metrics", "data": metrics_payload}
+                    yield f"data: {json.dumps(event)}\n\n"
+                elif isinstance(token, dict) and "__sections__" in token:
+                    event = {"type": "sections", "data": token["__sections__"]}
                     yield f"data: {json.dumps(event)}\n\n"
                 else:
                     # JSON-encode so embedded newlines and special chars survive SSE transport

--- a/services/backend/app/routers/chat_history.py
+++ b/services/backend/app/routers/chat_history.py
@@ -206,6 +206,7 @@ async def _resolve_provider(db: AsyncSession, user: User, provider_name: str):
             api_key=api_key,
             model=key_row.preferred_model,
             base_url=key_row.base_url,
+            org_name=key_row.org_name,
         )
     else:
         from app.models.site_setting import SiteSetting

--- a/services/backend/app/routers/ws.py
+++ b/services/backend/app/routers/ws.py
@@ -22,7 +22,13 @@ settings = get_settings()
 async def _authenticate_ws(token: str) -> User | None:
     """Authenticate a WebSocket connection using a JWT token."""
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        payload = jwt.decode(
+            token,
+            settings.secret_key,
+            algorithms=[settings.algorithm],
+            audience=settings.app_identifier,
+            issuer=settings.app_identifier,
+        )
         email = payload.get("sub")
         if not isinstance(email, str):
             return None

--- a/services/backend/app/schemas/user_api_key.py
+++ b/services/backend/app/schemas/user_api_key.py
@@ -13,6 +13,7 @@ class ApiKeyCreate(BaseModel):
     label: str | None = Field(None, max_length=128, description="Display label")
     base_url: str | None = Field(None, max_length=512, description="Custom API base URL override")
     preferred_model: str | None = Field(None, max_length=128, description="Preferred model name")
+    org_name: str | None = Field(None, max_length=200, description="GitHub org name for org-attributed inference")
 
 
 class ApiKeyUpdate(BaseModel):
@@ -20,6 +21,7 @@ class ApiKeyUpdate(BaseModel):
     label: str | None = None
     base_url: str | None = None
     preferred_model: str | None = None
+    org_name: str | None = None
     is_active: bool | None = None
     api_key: str | None = Field(None, min_length=1, description="New raw API key (re-encrypted)")
 
@@ -31,6 +33,7 @@ class ApiKeyResponse(BaseModel):
     label: str | None
     base_url: str | None
     preferred_model: str | None
+    org_name: str | None = None
     is_active: bool
     created_at: datetime
     updated_at: datetime

--- a/services/backend/app/services/search/providers/factory.py
+++ b/services/backend/app/services/search/providers/factory.py
@@ -12,6 +12,7 @@ def get_provider(
     api_key: str | None = None,
     model: str | None = None,
     base_url: str | None = None,
+    org_name: str | None = None,
 ) -> LLMProvider:
     """Create an LLMProvider instance for the given provider type.
 
@@ -39,6 +40,7 @@ def get_provider(
             api_key=api_key,
             model=model,
             base_url=base_url or GITHUB_MODELS_BASE_URL,
+            org_name=org_name,
         )
 
     if provider_type in ("openai", "xai", "gemini"):

--- a/services/backend/app/services/search/providers/github_models.py
+++ b/services/backend/app/services/search/providers/github_models.py
@@ -36,12 +36,20 @@ class GitHubModelsProvider(LLMProvider):
         api_key: str,
         model: str | None = None,
         base_url: str = GITHUB_MODELS_BASE_URL,
+        org_name: str | None = None,
     ):
         if not api_key:
             raise ValueError("api_key is required for GitHub Models provider")
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
         self._model = model or GITHUB_MODELS_DEFAULT_MODEL
+        self._org_name = org_name or ""
+
+    def _inference_url(self, path: str) -> str:
+        """Return the inference endpoint, routed through the org if configured."""
+        if self._org_name:
+            return f"{self._base_url}/orgs/{self._org_name}{path}"
+        return f"{self._base_url}{path}"
 
     @property
     def provider_name(self) -> str:
@@ -101,7 +109,7 @@ class GitHubModelsProvider(LLMProvider):
         async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
             async with client.stream(
                 "POST",
-                f"{self._base_url}/inference/chat/completions",
+                self._inference_url("/inference/chat/completions"),
                 json=payload,
                 headers=self._headers(),
             ) as response:

--- a/services/backend/app/services/search/providers/ollama.py
+++ b/services/backend/app/services/search/providers/ollama.py
@@ -78,7 +78,16 @@ class OllamaProvider(LLMProvider):
                 f"{self._url}/api/chat",
                 json=payload,
             ) as response:
-                response.raise_for_status()
+                if response.status_code != 200:
+                    body = await response.aread()
+                    detail = f"Ollama error {response.status_code}"
+                    try:
+                        err_data = json.loads(body)
+                        if msg := err_data.get("error", ""):
+                            detail += f": {msg}"
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+                    raise RuntimeError(detail)
                 async for line in response.aiter_lines():
                     if not line.strip():
                         continue

--- a/services/backend/app/services/search/qa.py
+++ b/services/backend/app/services/search/qa.py
@@ -39,7 +39,9 @@ _SYSTEM_PROMPT_SINGLE = (
     "Answer questions about the document below. "
     "Prioritise information from the document, but you may also use your general knowledge "
     "to supplement or provide additional context. When using general knowledge, indicate that "
-    "clearly. Reference the document by name. Be concise."
+    "clearly. Reference the document by name. Be concise. "
+    "When your response has distinct parts (context, main content, follow-up suggestions), "
+    "separate them with --- (horizontal rule)."
 )
 
 # Strict variant — restricts the LLM to document content only
@@ -47,7 +49,9 @@ _SYSTEM_PROMPT_SINGLE_STRICT = (
     "Answer questions about the document below. "
     "If the answer isn't in the document, say so. "
     "Do not use outside knowledge. "
-    "Reference the document by name. Be concise."
+    "Reference the document by name. Be concise. "
+    "When your response has distinct parts (context, main content, follow-up suggestions), "
+    "separate them with --- (horizontal rule)."
 )
 
 # System prompt for all-docs mode
@@ -56,7 +60,8 @@ You have: 1) CATALOGUE — list of recent documents, 2) EXCERPTS — content fro
 Use the catalogue for questions about what exists. Use excerpts for content questions.
 You may also draw on your general knowledge to supplement when the documents don't fully cover the topic — clearly indicate when you do.
 Always mention the exact document name when citing information so the user can find it.
-Be concise."""
+Be concise.
+When your response has distinct parts, separate them with --- (horizontal rule)."""
 
 # Strict variant — restricts the LLM to library content only
 _SYSTEM_PROMPT_ALL_STRICT = """Answer questions about the user's document library.
@@ -64,7 +69,8 @@ You have: 1) CATALOGUE — list of recent documents, 2) EXCERPTS — content fro
 Use the catalogue for questions about what exists. Use excerpts for content questions.
 Do not use outside knowledge — only answer from the provided documents.
 Always mention the exact document name when citing information so the user can find it.
-Be concise."""
+Be concise.
+When your response has distinct parts, separate them with --- (horizontal rule)."""
 
 
 class QAService:
@@ -148,6 +154,7 @@ class QAService:
 
         t_first_token = None
         token_count = 0
+        full_response_parts: list[str] = []
         async for token in self._provider.stream(
             user_prompt,
             system_prompt=system_prompt,
@@ -156,6 +163,7 @@ class QAService:
             if t_first_token is None:
                 t_first_token = time.monotonic()
             token_count += 1
+            full_response_parts.append(token)
             yield token
 
         t_done = time.monotonic()
@@ -176,6 +184,16 @@ class QAService:
             metrics["generation_ms"], metrics["total_ms"], metrics["tokens"],
         )
         yield metrics
+
+        # Parse response into logical sections and yield if multi-section
+        full_response = "".join(full_response_parts)
+        try:
+            from app.services.search.section_parser import parse_sections
+            sections = parse_sections(full_response)
+            if len(sections) >= 2:
+                yield {"__sections__": [dict(s) for s in sections]}
+        except Exception:
+            logger.debug("Section parsing failed; skipping sections event", exc_info=True)
 
     async def health_check(self) -> bool:
         """Return True if the LLM provider is reachable."""

--- a/services/backend/app/services/search/section_parser.py
+++ b/services/backend/app/services/search/section_parser.py
@@ -1,0 +1,140 @@
+"""Parse LLM response text into logical sections separated by thematic breaks (---)."""
+from __future__ import annotations
+
+import re
+from typing import TypedDict
+
+
+class ResponseSection(TypedDict):
+    type: str        # "context", "primary_content", or "follow_up"
+    label: str       # Human-readable label for UI display
+    content: str     # Raw markdown content of this section
+    confidence: float  # 0.0–1.0 confidence in the type classification
+
+
+# Matches a markdown thematic break: a line with 3+ dashes and optional whitespace
+_THEMATIC_BREAK = re.compile(r"^\s*-{3,}\s*$")
+
+# Matches a fenced code block opening/closing (``` or ~~~, with optional language tag)
+_FENCE = re.compile(r"^\s*(`{3,}|~{3,})")
+
+
+def parse_sections(text: str) -> list[ResponseSection]:
+    """Split *text* on ``---`` thematic breaks (outside fenced code blocks)
+    and classify each section heuristically.
+
+    Returns a list of :class:`ResponseSection` dicts.  If the text contains
+    no thematic breaks, a single ``primary_content`` section is returned.
+    """
+    if not text or not text.strip():
+        return []
+
+    sections_raw = _split_on_breaks(text)
+
+    # Filter empty sections
+    sections_raw = [s.strip() for s in sections_raw if s.strip()]
+
+    if not sections_raw:
+        return []
+
+    if len(sections_raw) == 1:
+        return [_make_section("primary_content", "Content", sections_raw[0], 1.0)]
+
+    return _classify_sections(sections_raw)
+
+
+def _split_on_breaks(text: str) -> list[str]:
+    """Split *text* on ``---`` lines that are NOT inside fenced code blocks."""
+    lines = text.split("\n")
+    sections: list[str] = []
+    current_lines: list[str] = []
+    in_fence = False
+    fence_char: str | None = None
+
+    for line in lines:
+        fence_match = _FENCE.match(line)
+        if fence_match:
+            char = fence_match.group(1)[0]  # '`' or '~'
+            if not in_fence:
+                in_fence = True
+                fence_char = char
+            elif char == fence_char:
+                in_fence = False
+                fence_char = None
+            current_lines.append(line)
+            continue
+
+        if not in_fence and _THEMATIC_BREAK.match(line):
+            # This is a section boundary — don't include the --- line itself
+            sections.append("\n".join(current_lines))
+            current_lines = []
+            continue
+
+        current_lines.append(line)
+
+    # Flush remaining content
+    if current_lines:
+        sections.append("\n".join(current_lines))
+
+    return sections
+
+
+def _classify_sections(sections: list[str]) -> list[ResponseSection]:
+    """Assign type/label/confidence to an ordered list of raw section texts."""
+    total_chars = sum(len(s) for s in sections)
+    results: list[ResponseSection] = []
+
+    for idx, content in enumerate(sections):
+        is_first = idx == 0
+        is_last = idx == len(sections) - 1
+
+        # --- Follow-up detection (last section) ---
+        if is_last:
+            q_conf = _question_confidence(content)
+            if q_conf >= 0.5:
+                results.append(_make_section("follow_up", "Follow-up questions", content, q_conf))
+                continue
+
+        # --- Context detection (first section) ---
+        if is_first:
+            # Short preamble relative to total = higher confidence it's context
+            ratio = len(content) / total_chars if total_chars else 0
+            if ratio < 0.35:
+                confidence = min(1.0, 0.6 + (0.35 - ratio))
+                results.append(_make_section("context", "Context", content, round(confidence, 2)))
+                continue
+
+        # --- Default: primary content ---
+        results.append(_make_section("primary_content", "Content", content, 0.9))
+
+    return results
+
+
+def _question_confidence(text: str) -> float:
+    """Return confidence (0–1) that *text* is a follow-up questions section."""
+    lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
+    if not lines:
+        return 0.0
+
+    question_lines = sum(1 for ln in lines if ln.rstrip().endswith("?"))
+    # Also count numbered/bulleted items ending with ?
+    ratio = question_lines / len(lines) if lines else 0
+
+    # Boost confidence if most lines are questions
+    if ratio >= 0.6:
+        return min(1.0, 0.5 + ratio * 0.5)
+    return round(ratio * 0.5, 2)
+
+
+def _make_section(
+    section_type: str,
+    label: str,
+    content: str,
+    confidence: float,
+) -> ResponseSection:
+    return ResponseSection(
+        type=section_type,
+        label=label,
+        content=content.strip(),
+        confidence=round(confidence, 2),
+    )

--- a/services/backend/migrations/versions/a1b2c3d4e5f7_fix_documents_timestamp_defaults.py
+++ b/services/backend/migrations/versions/a1b2c3d4e5f7_fix_documents_timestamp_defaults.py
@@ -1,0 +1,57 @@
+"""fix documents timestamp defaults and nullable
+
+Revision ID: a1b2c3d4e5f7
+Revises: e9f0a1b2c3d4
+Create Date: 2026-04-15 09:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f7"
+down_revision: Union[str, None] = "e9f0a1b2c3d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Fill any NULL timestamps before applying NOT NULL
+    op.execute("UPDATE documents SET created_at = now() WHERE created_at IS NULL")
+    op.execute("UPDATE documents SET updated_at = now() WHERE updated_at IS NULL")
+
+    # Ensure server defaults exist
+    op.alter_column(
+        "documents",
+        "created_at",
+        existing_type=sa.DateTime(timezone=True),
+        server_default=sa.text("now()"),
+        nullable=False,
+    )
+    op.alter_column(
+        "documents",
+        "updated_at",
+        existing_type=sa.DateTime(timezone=True),
+        server_default=sa.text("now()"),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "documents",
+        "updated_at",
+        existing_type=sa.DateTime(timezone=True),
+        server_default=sa.text("now()"),
+        nullable=True,
+    )
+    op.alter_column(
+        "documents",
+        "created_at",
+        existing_type=sa.DateTime(timezone=True),
+        server_default=sa.text("now()"),
+        nullable=True,
+    )

--- a/services/backend/migrations/versions/f0a1b2c3d4e5_add_org_name_to_user_api_keys.py
+++ b/services/backend/migrations/versions/f0a1b2c3d4e5_add_org_name_to_user_api_keys.py
@@ -1,0 +1,26 @@
+"""add_org_name_to_user_api_keys
+
+Revision ID: f0a1b2c3d4e5
+Revises: a1b2c3d4e5f7
+Create Date: 2026-04-17 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f0a1b2c3d4e5"
+down_revision: Union[str, None] = "a1b2c3d4e5f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_api_keys", sa.Column("org_name", sa.String(200), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_api_keys", "org_name")

--- a/services/embedding/Dockerfile
+++ b/services/embedding/Dockerfile
@@ -15,13 +15,20 @@ COPY pyproject.toml poetry.lock* ./
 RUN poetry config virtualenvs.create false \
     && poetry install --only=main --no-root --no-interaction --no-ansi
 
+# Pre-download the model at build time so the container never needs
+# network access to HuggingFace at runtime (~90MB cached in image)
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+
 # Copy application code
 COPY app/ ./app/
 
 ENV PYTHONPATH=/embedding
 ENV PYTHONUNBUFFERED=1
+# Use cached model only — never reach out to HuggingFace at runtime
+ENV HF_HUB_OFFLINE=1
+ENV TRANSFORMERS_OFFLINE=1
 
-HEALTHCHECK --interval=30s --timeout=30s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=30s --start-period=300s --retries=5 \
     CMD curl -f http://localhost:8005/health || exit 1
 
 # Use 1 worker — model is a singleton; multiple workers waste memory

--- a/services/ui/src/api/userApi.js
+++ b/services/ui/src/api/userApi.js
@@ -1,6 +1,19 @@
 import { Api } from "./api";
 
 class UserAPI extends Api {
+  // Check for a cross-app SSO cookie and bootstrap a local session
+  async ssoCheck() {
+    try {
+      console.log('UserAPI.ssoCheck: Attempting SSO check');
+      const res = await this.apiCall("/auth/sso-check", "GET", null, {}, { withCredentials: true, noAuth: true });
+      console.log('UserAPI.ssoCheck: SSO check result', res.data);
+      return res.data;
+    } catch (error) {
+      console.log('UserAPI.ssoCheck: SSO check failed', error?.response?.status);
+      return null;
+    }
+  }
+
   // Request a new access token using the refresh token cookie
   async refreshToken() {
     try {

--- a/services/ui/src/components/auth/modals/SSORegisterModal.jsx
+++ b/services/ui/src/components/auth/modals/SSORegisterModal.jsx
@@ -1,0 +1,158 @@
+import React, { useState, useRef } from "react";
+import { Modal, Button, Form, Row, Col, Alert, Badge } from "react-bootstrap";
+
+/**
+ * SSO Registration Modal — shown when a cross-app SSO token exists
+ * but no local account matches the email. Email is pre-filled and read-only;
+ * user provides name + password to create a linked account.
+ */
+function SSORegisterModal({ show, onHide, onRegister, email, issuer, error }) {
+  const firstNameRef = useRef(null);
+  const [form, setForm] = useState({
+    first_name: "",
+    last_name: "",
+    display_name: "",
+    password: "",
+    confirm_password: "",
+  });
+  const [passwordMatchError, setPasswordMatchError] = useState("");
+
+  const handleChange = (e) => {
+    const { id, value } = e.target;
+    setForm({ ...form, [id]: value });
+
+    if (id === "password" || id === "confirm_password") {
+      if (
+        (id === "password" && value !== form.confirm_password) ||
+        (id === "confirm_password" && value !== form.password)
+      ) {
+        setPasswordMatchError("Passwords do not match.");
+      } else {
+        setPasswordMatchError("");
+      }
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!form.first_name || !form.last_name) {
+      return;
+    }
+    if (!form.password || form.password.length < 6) {
+      setPasswordMatchError("Password must be at least 6 characters.");
+      return;
+    }
+    if (form.password !== form.confirm_password) {
+      setPasswordMatchError("Passwords do not match.");
+      return;
+    }
+    if (onRegister) {
+      onRegister({
+        ...form,
+        email,
+        confirm_email: email,
+      });
+    }
+  };
+
+  const issuerLabel = issuer === "team-manager" ? "Team Manager" : issuer || "another app";
+
+  return (
+    <Modal show={show} onHide={onHide} centered onEntered={() => firstNameRef.current?.focus()}>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          <i className="bi bi-link-45deg me-2"></i>Link Your Account
+        </Modal.Title>
+      </Modal.Header>
+      <Form onSubmit={handleSubmit}>
+        <Modal.Body>
+          <Alert variant="info" className="d-flex align-items-center gap-2">
+            <i className="bi bi-info-circle"></i>
+            <span>
+              You're signed in on <strong>{issuerLabel}</strong> as{" "}
+              <Badge bg="primary">{email}</Badge>.
+              Create an account here to link them.
+            </span>
+          </Alert>
+
+          <Form.Group className="mb-3" controlId="sso_email">
+            <Form.Label>Email</Form.Label>
+            <Form.Control type="email" value={email} readOnly disabled />
+          </Form.Group>
+
+          <Row className="mb-3">
+            <Col md={6}>
+              <Form.Group controlId="first_name">
+                <Form.Label>First Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={form.first_name}
+                  onChange={handleChange}
+                  required
+                  ref={firstNameRef}
+                />
+              </Form.Group>
+            </Col>
+            <Col md={6}>
+              <Form.Group controlId="last_name">
+                <Form.Label>Last Name</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={form.last_name}
+                  onChange={handleChange}
+                  required
+                />
+              </Form.Group>
+            </Col>
+          </Row>
+
+          <Form.Group className="mb-3" controlId="display_name">
+            <Form.Label>Display Name (Optional)</Form.Label>
+            <Form.Control
+              type="text"
+              value={form.display_name}
+              onChange={handleChange}
+              placeholder="How you'd like to be shown in the app"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3" controlId="password">
+            <Form.Label>Password</Form.Label>
+            <Form.Control
+              type="password"
+              value={form.password}
+              onChange={handleChange}
+              required
+              minLength={6}
+            />
+            <Form.Text>Password must be at least 6 characters long.</Form.Text>
+          </Form.Group>
+
+          <Form.Group className="mb-3" controlId="confirm_password">
+            <Form.Label>Confirm Password</Form.Label>
+            <Form.Control
+              type="password"
+              value={form.confirm_password}
+              onChange={handleChange}
+              required
+              minLength={6}
+            />
+          </Form.Group>
+
+          {passwordMatchError && <Alert variant="danger">{passwordMatchError}</Alert>}
+          {error && <Alert variant="danger">{error}</Alert>}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={onHide}>
+            Skip
+          </Button>
+          <Button type="submit" variant="primary">
+            <i className="bi bi-link-45deg me-1"></i>Create & Link Account
+          </Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+}
+
+export default SSORegisterModal;

--- a/services/ui/src/components/chat/ChatDrawer.jsx
+++ b/services/ui/src/components/chat/ChatDrawer.jsx
@@ -352,7 +352,13 @@ function ChatDrawer({ show, onHide }) {
   const handlePickerProviderSelect = useCallback((providerEntry) => {
     setPickerProvider(providerEntry);
     fetchModelsForPicker(providerEntry);
-  }, [fetchModelsForPicker]);
+    // Immediately switch the active provider so the next chat uses it,
+    // and clear stale model (model IDs are provider-specific).
+    if (providerEntry.keyId !== selectedProvider.keyId || providerEntry.provider !== selectedProvider.provider) {
+      setSelectedProvider(providerEntry);
+      setSelectedModel(null);
+    }
+  }, [fetchModelsForPicker, selectedProvider]);
 
   // Model picker: select a model and close
   const handleModelSelect = useCallback((modelEntry, providerEntry) => {

--- a/services/ui/src/components/chat/ChatDrawer.jsx
+++ b/services/ui/src/components/chat/ChatDrawer.jsx
@@ -181,6 +181,19 @@ function ChatDrawer({ show, onHide }) {
     if (show) history.loadConversations();
   }, [show]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Restore the persisted active conversation when drawer opens with no messages loaded
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (!show || restoredRef.current || messages.length > 0) return;
+    const persistedId = history.activeConversationId;
+    if (!persistedId) return;
+    restoredRef.current = true;
+    // Load the persisted conversation; clear stale ID on failure (e.g. deleted)
+    handleHistorySelect(persistedId).catch(() => {
+      history.clearActive();
+    });
+  }, [show]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Fetch user's configured AI providers when drawer opens
   useEffect(() => {
     if (!show) return;
@@ -836,6 +849,10 @@ function ChatDrawer({ show, onHide }) {
             { provider: detail.provider, keyId: null };
           setSelectedProvider(match);
         }
+    } else {
+      // Conversation no longer exists — clear stale active state
+      history.clearActive();
+      setMessages([]);
     }
     setShowHistory(false);
   };

--- a/services/ui/src/components/chat/ChatDrawer.jsx
+++ b/services/ui/src/components/chat/ChatDrawer.jsx
@@ -8,6 +8,7 @@ import categoriesApi from "@/api/categoriesApi";
 import { useDocumentContext } from "@/providers/DocumentContextProvider.jsx";
 import useChatEditorActions from "@/hooks/chat/useChatEditorActions";
 import useChatHistory from "@/hooks/chat/useChatHistory";
+import { parseSections } from "@/utils/chatSectionParser";
 import ChatHistoryPanel from "./ChatHistoryPanel";
 
 // Shared markdown-it instance — html disabled for XSS safety
@@ -155,6 +156,7 @@ function ChatDrawer({ show, onHide }) {
   // Selection context for chat
   const [useSelection, setUseSelection] = useState(true); // auto-include editor selection
   const [replaceConfirm, setReplaceConfirm] = useState(null); // message index for confirmation
+  const [sectionSelections, setSectionSelections] = useState({}); // msgIdx → selected section index (or "full")
 
   // Edit mode state
   const [editingMessageIndex, setEditingMessageIndex] = useState(null);
@@ -493,6 +495,18 @@ function ChatDrawer({ show, onHide }) {
             });
             return;
           }
+          // Handle sections object from server (post-completion section parsing)
+          if (token && typeof token === "object" && token.type === "sections") {
+            setMessages((prev) => {
+              const updated = [...prev];
+              const last = updated[updated.length - 1];
+              if (last?.role === "assistant") {
+                updated[updated.length - 1] = { ...last, sections: token.data };
+              }
+              return updated;
+            });
+            return;
+          }
           setMessages((prev) => {
             const updated = [...prev];
             const last = updated[updated.length - 1];
@@ -549,6 +563,7 @@ function ChatDrawer({ show, onHide }) {
             const metaObj = {};
             if (duration) metaObj.duration = duration;
             if (last.serverMetrics) metaObj.serverMetrics = last.serverMetrics;
+            if (last.sections?.length >= 2) metaObj.sections = last.sections;
             const metaJson = Object.keys(metaObj).length ? JSON.stringify(metaObj) : null;
             history.saveMessage(convId, "assistant", last.content, metaJson);
 
@@ -684,6 +699,7 @@ function ChatDrawer({ show, onHide }) {
           const metaObj = {};
           if (duration) metaObj.duration = duration;
           if (aMsg.serverMetrics) metaObj.serverMetrics = aMsg.serverMetrics;
+          if (aMsg.sections?.length >= 2) metaObj.sections = aMsg.sections;
           if (aMsg.responseGroupId) {
             metaObj.responseGroupId = aMsg.responseGroupId;
             metaObj.responseVersion = aMsg.versions ? aMsg.versions.length - 1 : 0;
@@ -787,6 +803,7 @@ function ChatDrawer({ show, onHide }) {
     setIsStreaming(false);
     setEditingMessageIndex(null);
     setEditInput("");
+    setSectionSelections({});
     history.clearActive();
     setShowHistory(false);
   };
@@ -843,6 +860,7 @@ function ChatDrawer({ show, onHide }) {
       }
 
       setMessages(groupedMessages);
+      setSectionSelections({});
       if (detail.scope) setScope(detail.scope);
         if (detail.provider) {
           const match = availableProviders.find((p) => p.provider === detail.provider) ||
@@ -1150,7 +1168,7 @@ function ChatDrawer({ show, onHide }) {
                     </div>
                   ) : (
                     <>
-                      <div className={`message-bubble${msg.streaming ? " streaming-cursor" : ""}`}>
+                      <div className={`message-bubble${msg.streaming ? " streaming" : ""}`}>
                         {msg.role === "assistant" ? (
                           <div
                             dangerouslySetInnerHTML={{
@@ -1161,6 +1179,13 @@ function ChatDrawer({ show, onHide }) {
                           />
                         ) : (
                           <div dangerouslySetInnerHTML={{ __html: md.render(msg.content || "") }} />
+                        )}
+                        {msg.role === "assistant" && msg.streaming && (
+                          <span className="typing-indicator">
+                            <i className="bi bi-circle-fill" />
+                            <i className="bi bi-circle-fill" />
+                            <i className="bi bi-circle-fill" />
+                          </span>
                         )}
                       </div>
                       {/* Resend + Edit icons on the last user message only */}
@@ -1211,12 +1236,28 @@ function ChatDrawer({ show, onHide }) {
                     </div>
                   )}
                   {/* Action buttons for completed assistant messages */}
-                  {msg.role === "assistant" && !msg.streaming && msg.content && !msg.isAction && (
+                  {msg.role === "assistant" && !msg.streaming && msg.content && !msg.isAction && (() => {
+                    // Resolve sections: from SSE, stored metadata, or client-side fallback
+                    const sections = msg.sections?.length >= 2
+                      ? msg.sections
+                      : (!msg.sections ? parseSections(msg.content) : null);
+                    const hasSections = sections && sections.length >= 2;
+                    const selectedVal = sectionSelections[idx];
+                    // Default to the first primary_content section
+                    const defaultIdx = hasSections
+                      ? sections.findIndex((s) => s.type === "primary_content")
+                      : -1;
+                    const activeIdx = selectedVal !== undefined ? selectedVal : (defaultIdx >= 0 ? defaultIdx : "full");
+                    const activeContent = hasSections && activeIdx !== "full"
+                      ? sections[activeIdx]?.content || msg.content
+                      : msg.content;
+
+                    return (
                     <div className="message-actions">
                       {replaceConfirm === idx ? (
                         <span className="replace-confirm">
                           <span className="replace-confirm-text">Replace entire document?</span>
-                          <button type="button" className="action-btn confirm-yes" title="Yes, replace" onClick={() => { editorActions.replaceDocument(msg.content); setReplaceConfirm(null); }}>
+                          <button type="button" className="action-btn confirm-yes" title="Yes, replace" onClick={() => { editorActions.replaceDocument(activeContent); setReplaceConfirm(null); }}>
                             <i className="bi bi-check-lg" />
                           </button>
                           <button type="button" className="action-btn confirm-no" title="Cancel" onClick={() => setReplaceConfirm(null)}>
@@ -1225,25 +1266,46 @@ function ChatDrawer({ show, onHide }) {
                         </span>
                       ) : (
                         <>
-                          <button type="button" className="action-btn" title="Insert at cursor" onClick={() => editorActions.insertAtCursor(msg.content)}>
+                          {hasSections && (
+                            <select
+                              className="section-selector"
+                              value={activeIdx}
+                              onChange={(e) => {
+                                const val = e.target.value === "full" ? "full" : Number(e.target.value);
+                                setSectionSelections((prev) => ({ ...prev, [idx]: val }));
+                              }}
+                              title="Choose which section to use"
+                            >
+                              {sections.map((s, si) => (
+                                <option key={si} value={si}>
+                                  {s.confidence >= 0.7
+                                    ? s.label
+                                    : (s.content.slice(0, 30) + (s.content.length > 30 ? "…" : ""))}
+                                </option>
+                              ))}
+                              <option value="full">Full response</option>
+                            </select>
+                          )}
+                          <button type="button" className="action-btn" title="Insert at cursor" onClick={() => editorActions.insertAtCursor(activeContent)}>
                             <i className="bi bi-cursor-text" />
                           </button>
-                          <button type="button" className="action-btn" title="Replace selection" disabled={!editorSelection?.text} onClick={() => editorActions.replaceSelection(msg.content)}>
+                          <button type="button" className="action-btn" title="Replace selection" disabled={!editorSelection?.text} onClick={() => editorActions.replaceSelection(activeContent)}>
                             <i className="bi bi-input-cursor" />
                           </button>
                           <button type="button" className="action-btn" title="Replace document" onClick={() => setReplaceConfirm(idx)}>
                             <i className="bi bi-file-earmark-arrow-up" />
                           </button>
-                          <button type="button" className="action-btn" title="Append to document" onClick={() => editorActions.appendToDocument(msg.content)}>
+                          <button type="button" className="action-btn" title="Append to document" onClick={() => editorActions.appendToDocument(activeContent)}>
                             <i className="bi bi-file-earmark-plus" />
                           </button>
-                          <button type="button" className="action-btn" title="Copy to clipboard" onClick={() => editorActions.copyToClipboard(msg.content)}>
+                          <button type="button" className="action-btn" title="Copy to clipboard" onClick={() => editorActions.copyToClipboard(activeContent)}>
                             <i className="bi bi-clipboard" />
                           </button>
                         </>
                       )}
                     </div>
-                  )}
+                    );
+                  })()}
                 </div>
               ));
             })()

--- a/services/ui/src/components/user/modals/AIProvidersTab.jsx
+++ b/services/ui/src/components/user/modals/AIProvidersTab.jsx
@@ -57,6 +57,8 @@ function KeyCard({ keyData, provider, onSaved, onDeleted }) {
   const [label, setLabel] = useState(keyData?.label || '');
   const [baseUrl, setBaseUrl] = useState(keyData?.base_url || '');
   const [model, setModel] = useState(keyData?.preferred_model || provider.defaultModel);
+  const [orgName, setOrgName] = useState(keyData?.org_name || '');
+  const [orgEnabled, setOrgEnabled] = useState(!!keyData?.org_name);
   const [models, setModels] = useState([]);
   const [loadingModels, setLoadingModels] = useState(false);
   const [modelError, setModelError] = useState('');
@@ -99,9 +101,10 @@ function KeyCard({ keyData, provider, onSaved, onDeleted }) {
         label: label || provider.name,
         base_url: baseUrl || undefined,
         preferred_model: model,
+        org_name: (provider.id === 'github' && orgEnabled) ? orgName : undefined,
       };
       if (isConfigured) {
-        const updates = { label: data.label, base_url: data.base_url, preferred_model: data.preferred_model };
+        const updates = { label: data.label, base_url: data.base_url, preferred_model: data.preferred_model, org_name: data.org_name || '' };
         if (apiKey) updates.api_key = apiKey;
         await apiKeysApi.updateKey(keyData.id, updates);
       } else {
@@ -221,6 +224,34 @@ function KeyCard({ keyData, provider, onSaved, onDeleted }) {
             <Form.Text className="text-muted">Override if using a custom endpoint</Form.Text>
           </Form.Group>
         </Col>
+        {provider.id === 'github' && (
+          <Col xs={12}>
+            <Form.Check
+              type="switch"
+              id={`org-toggle-${keyData?.id || 'new'}`}
+              label="Use organization rate limits"
+              checked={orgEnabled}
+              onChange={(e) => {
+                setOrgEnabled(e.target.checked);
+                if (!e.target.checked) setOrgName('');
+              }}
+              className="mt-2"
+            />
+            {orgEnabled && (
+              <Form.Group className="mt-2">
+                <Form.Control
+                  type="text"
+                  placeholder="my-org"
+                  value={orgName}
+                  onChange={(e) => setOrgName(e.target.value)}
+                />
+                <Form.Text className="text-muted">
+                  GitHub org login name. Requires an org-scoped PAT with Models: Read permission.
+                </Form.Text>
+              </Form.Group>
+            )}
+          </Col>
+        )}
       </Row>
 
       <div className="d-flex gap-2 mt-3">

--- a/services/ui/src/hooks/chat/useChatHistory.js
+++ b/services/ui/src/hooks/chat/useChatHistory.js
@@ -1,5 +1,7 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { chatHistoryApi } from "@/api/chatHistoryApi";
+
+const STORAGE_KEY = "chat_active_conversation";
 
 /**
  * Hook for managing chat conversation history.
@@ -7,9 +9,25 @@ import { chatHistoryApi } from "@/api/chatHistoryApi";
  */
 export default function useChatHistory() {
   const [conversations, setConversations] = useState([]);
-  const [activeConversationId, setActiveConversationId] = useState(null);
+  const [activeConversationId, setActiveConversationId] = useState(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      return saved ? Number(saved) || null : null;
+    } catch { return null; }
+  });
   const [loading, setLoading] = useState(false);
   const titleGenPending = useRef(new Set());
+
+  // Sync activeConversationId to localStorage
+  useEffect(() => {
+    try {
+      if (activeConversationId != null) {
+        localStorage.setItem(STORAGE_KEY, String(activeConversationId));
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch { /* ignore */ }
+  }, [activeConversationId]);
 
   const loadConversations = useCallback(async () => {
     setLoading(true);

--- a/services/ui/src/providers/AuthProvider.jsx
+++ b/services/ui/src/providers/AuthProvider.jsx
@@ -6,7 +6,9 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import AuthService from '@/services/core/AuthService';
+import UserAPI from '@/api/userApi';
 import LoginModal from '../components/auth/modals/LoginModal.jsx';
+import SSORegisterModal from '../components/auth/modals/SSORegisterModal.jsx';
 import VerifyMFAModal from '../components/security/modals/VerifyMFAModal.jsx';
 import PasswordResetModal from '../components/auth/modals/PasswordResetModal.jsx';
 import LogoutProgressModal from '../components/LogoutProgressModal.jsx';
@@ -23,6 +25,12 @@ export function AuthProvider({ children }) {
   const [showMFAModal, setShowMFAModal] = useState(false);
   const [showPasswordResetModal, setShowPasswordResetModal] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [showSSORegisterModal, setShowSSORegisterModal] = useState(false);
+  const [ssoRegisterError, setSSORegisterError] = useState('');
+
+  // SSO linking state
+  const [ssoEmail, setSsoEmail] = useState(null);
+  const [ssoIssuer, setSsoIssuer] = useState(null);
 
   // MFA state
   const [pendingEmail, setPendingEmail] = useState("");
@@ -72,6 +80,14 @@ export function AuthProvider({ children }) {
       console.log('AuthContext: AuthService initialization complete');
       updateAuthState();
       setIsInitializing(false);
+
+      // Check if SSO detected an unlinked account
+      const state = AuthService.getAuthState();
+      if (state.ssoEmail) {
+        setSsoEmail(state.ssoEmail);
+        setSsoIssuer(state.ssoIssuer || '');
+        setShowSSORegisterModal(true);
+      }
     };
 
     initializeAuth();
@@ -120,6 +136,30 @@ export function AuthProvider({ children }) {
       return { success: false, error: error.message };
     }
   }, [updateAuthState]);
+
+  const handleSSORegister = useCallback(async (formData) => {
+    try {
+      setSSORegisterError('');
+      await UserAPI.register(formData);
+      setShowSSORegisterModal(false);
+      setSsoEmail(null);
+      setSsoIssuer(null);
+      AuthService.clearSsoState();
+      // After registration, show login modal so user can sign in
+      setLoginEmail(formData.email || '');
+      setShowLoginModal(true);
+    } catch (error) {
+      console.error('SSO registration error:', error);
+      setSSORegisterError(error.message || 'Registration failed.');
+    }
+  }, []);
+
+  const handleDismissSSORegister = useCallback(() => {
+    setShowSSORegisterModal(false);
+    setSsoEmail(null);
+    setSsoIssuer(null);
+    AuthService.clearSsoState();
+  }, []);
 
   const verifyMFA = useCallback(async (code) => {
     setMFALoading(true);
@@ -363,6 +403,15 @@ export function AuthProvider({ children }) {
         onForceLogout={forceLogout}
         onCanceled={cancelLogout}
         config={logoutConfig}
+      />
+
+      <SSORegisterModal
+        show={showSSORegisterModal}
+        onHide={handleDismissSSORegister}
+        onRegister={handleSSORegister}
+        email={ssoEmail || ''}
+        issuer={ssoIssuer || ''}
+        error={ssoRegisterError}
       />
     </AuthContext.Provider>
   );

--- a/services/ui/src/services/core/AuthService.js
+++ b/services/ui/src/services/core/AuthService.js
@@ -34,6 +34,8 @@ class AuthService {
     this.justLoggedIn = false;
     this.initializationPromise = null;
     this.isInitialized = false;
+    this.ssoEmail = null;
+    this.ssoIssuer = null;
 
     // Initialization is deferred to waitForInitialization()
     // to avoid firing API requests during module evaluation
@@ -127,10 +129,38 @@ class AuthService {
             this.performLogout();
           }
         } else {
-          console.log('AuthService: No stored token, setting guest state');
-          this.setUser(defaultUser);
-          this.isAuthenticated = false;
-          localStorage.setItem('lastKnownAuthState', 'unauthenticated');
+          console.log('AuthService: No stored token, trying SSO check');
+          // Try cross-app SSO before falling back to guest state
+          const ssoResult = await UserAPI.ssoCheck();
+          if (ssoResult && ssoResult.access_token) {
+            console.log('AuthService: SSO check successful, bootstrapping session');
+            this.setToken(ssoResult.access_token);
+            const user = await this.fetchCurrentUser(ssoResult.access_token);
+            if (user) {
+              console.log('AuthService: SSO user validation successful', user.email);
+              this.setUser(user);
+              this.isAuthenticated = true;
+              this.startTokenRefresh();
+              localStorage.setItem('lastKnownAuthState', 'authenticated');
+            } else {
+              console.log('AuthService: SSO user validation failed');
+              this.setUser(defaultUser);
+              this.isAuthenticated = false;
+              localStorage.setItem('lastKnownAuthState', 'unauthenticated');
+            }
+          } else if (ssoResult && ssoResult.linked === false) {
+            console.log('AuthService: SSO token valid but no local account, email:', ssoResult.email);
+            this.ssoEmail = ssoResult.email;
+            this.ssoIssuer = ssoResult.issuer || '';
+            this.setUser(defaultUser);
+            this.isAuthenticated = false;
+            localStorage.setItem('lastKnownAuthState', 'unauthenticated');
+          } else {
+            console.log('AuthService: SSO check failed or not configured, setting guest state');
+            this.setUser(defaultUser);
+            this.isAuthenticated = false;
+            localStorage.setItem('lastKnownAuthState', 'unauthenticated');
+          }
         }
       }
     } catch (err) {
@@ -166,8 +196,18 @@ class AuthService {
     return {
       user: this.user,
       token: this.token,
-      isAuthenticated: this.isAuthenticated
+      isAuthenticated: this.isAuthenticated,
+      ssoEmail: this.ssoEmail,
+      ssoIssuer: this.ssoIssuer,
     };
+  }
+
+  /**
+   * Clear SSO linking state (after user dismisses or completes SSO registration)
+   */
+  clearSsoState() {
+    this.ssoEmail = null;
+    this.ssoIssuer = null;
   }
 
   /**

--- a/services/ui/src/styles/chat/_drawer.scss
+++ b/services/ui/src/styles/chat/_drawer.scss
@@ -209,14 +209,35 @@
     .empty-hint { font-size: 0.8rem; }
   }
 
-  // Blinking cursor for streaming
-  .streaming-cursor::after {
-    content: "▋";
-    animation: blink 0.7s step-end infinite;
+  // Typing indicator — iMessage/Teams-style bouncing dots
+  .typing-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 4px;
+    vertical-align: middle;
+
+    .bi-circle-fill {
+      font-size: 0.32rem;
+      color: var(--bs-secondary-color);
+      opacity: 0.5;
+      animation: typing-bounce 1.4s ease-in-out infinite;
+
+      &:nth-child(1) { animation-delay: 0s; }
+      &:nth-child(2) { animation-delay: 0.2s; }
+      &:nth-child(3) { animation-delay: 0.4s; }
+    }
   }
 
-  @keyframes blink {
-    50% { opacity: 0; }
+  @keyframes typing-bounce {
+    0%, 60%, 100% {
+      transform: translateY(0);
+      opacity: 0.35;
+    }
+    30% {
+      transform: translateY(-4px);
+      opacity: 1;
+    }
   }
 }
 
@@ -817,6 +838,39 @@
   gap: 2px;
   margin-top: 4px;
   padding: 2px 0;
+
+  .section-selector {
+    appearance: none;
+    -webkit-appearance: none;
+    background: rgba(var(--bs-secondary-rgb), 0.06);
+    border: 1px solid rgba(var(--bs-secondary-rgb), 0.15);
+    border-radius: 4px;
+    padding: 1px 18px 1px 5px;
+    font-size: 0.68rem;
+    color: var(--bs-secondary-color);
+    cursor: pointer;
+    line-height: 1.3;
+    max-width: 130px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: 3px;
+    transition: all 0.15s;
+    // Custom dropdown arrow
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Cpath fill='%236c757d' d='M1.5 2.5l2.5 3 2.5-3z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 4px center;
+
+    &:hover {
+      border-color: rgba(var(--bs-primary-rgb), 0.3);
+      background-color: rgba(var(--bs-primary-rgb), 0.06);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: rgba(var(--bs-primary-rgb), 0.4);
+    }
+  }
 
   .action-btn {
     background: none;

--- a/services/ui/src/utils/chatSectionParser.js
+++ b/services/ui/src/utils/chatSectionParser.js
@@ -1,0 +1,138 @@
+/**
+ * Parse LLM response text into logical sections separated by thematic breaks (---).
+ * Client-side mirror of backend section_parser.py for fallback use.
+ *
+ * @param {string} text - Raw markdown response text
+ * @returns {Array<{type: string, label: string, content: string, confidence: number}>}
+ */
+
+const THEMATIC_BREAK = /^\s*-{3,}\s*$/;
+const FENCE = /^\s*(`{3,}|~{3,})/;
+
+/**
+ * Split text on `---` lines that are NOT inside fenced code blocks.
+ */
+function splitOnBreaks(text) {
+  const lines = text.split("\n");
+  const sections = [];
+  let currentLines = [];
+  let inFence = false;
+  let fenceChar = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(FENCE);
+    if (fenceMatch) {
+      const char = fenceMatch[1][0]; // '`' or '~'
+      if (!inFence) {
+        inFence = true;
+        fenceChar = char;
+      } else if (char === fenceChar) {
+        inFence = false;
+        fenceChar = null;
+      }
+      currentLines.push(line);
+      continue;
+    }
+
+    if (!inFence && THEMATIC_BREAK.test(line)) {
+      sections.push(currentLines.join("\n"));
+      currentLines = [];
+      continue;
+    }
+
+    currentLines.push(line);
+  }
+
+  if (currentLines.length) {
+    sections.push(currentLines.join("\n"));
+  }
+
+  return sections;
+}
+
+/**
+ * Return confidence (0–1) that text is a follow-up questions section.
+ */
+function questionConfidence(text) {
+  const lines = text
+    .trim()
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (!lines.length) return 0;
+
+  const questionLines = lines.filter((l) => l.endsWith("?")).length;
+  const ratio = questionLines / lines.length;
+
+  if (ratio >= 0.6) return Math.min(1.0, 0.5 + ratio * 0.5);
+  return Math.round(ratio * 0.5 * 100) / 100;
+}
+
+function makeSection(type, label, content, confidence) {
+  return {
+    type,
+    label,
+    content: content.trim(),
+    confidence: Math.round(confidence * 100) / 100,
+  };
+}
+
+/**
+ * Assign type/label/confidence to an ordered list of raw section texts.
+ */
+function classifySections(sections) {
+  const totalChars = sections.reduce((sum, s) => sum + s.length, 0);
+  const results = [];
+
+  for (let idx = 0; idx < sections.length; idx++) {
+    const content = sections[idx];
+    const isFirst = idx === 0;
+    const isLast = idx === sections.length - 1;
+
+    // Follow-up detection (last section)
+    if (isLast) {
+      const qConf = questionConfidence(content);
+      if (qConf >= 0.5) {
+        results.push(makeSection("follow_up", "Follow-up questions", content, qConf));
+        continue;
+      }
+    }
+
+    // Context detection (first section)
+    if (isFirst) {
+      const ratio = totalChars ? content.length / totalChars : 0;
+      if (ratio < 0.35) {
+        const confidence = Math.min(1.0, 0.6 + (0.35 - ratio));
+        results.push(makeSection("context", "Context", content, confidence));
+        continue;
+      }
+    }
+
+    // Default: primary content
+    results.push(makeSection("primary_content", "Content", content, 0.9));
+  }
+
+  return results;
+}
+
+/**
+ * Parse response text into classified sections.
+ *
+ * @param {string} text - Raw markdown response text
+ * @returns {Array<{type: string, label: string, content: string, confidence: number}>}
+ */
+export function parseSections(text) {
+  if (!text || !text.trim()) return [];
+
+  const sectionsRaw = splitOnBreaks(text)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (!sectionsRaw.length) return [];
+
+  if (sectionsRaw.length === 1) {
+    return [makeSection("primary_content", "Content", sectionsRaw[0], 1.0)];
+  }
+
+  return classifySections(sectionsRaw);
+}


### PR DESCRIPTION
## Summary

Cross-app SSO with team-manager, chat UX improvements, infrastructure upgrades, and GitHub Models org-attributed inference.

### Features
- Cross-app SSO with team-manager
- Persist active chat conversation across drawer close and browser refresh
- Support GitHub Models org-attributed inference
- Section-aware chat action buttons with typing indicator

### Fixes
- Chat provider logging, Ollama error handling, and provider switch
- Embedding cold-start failures and deploy health check timeouts
- WebSocket JWT audience validation and documents timestamp defaults

### Chores & Docs
- Upgrade PostgreSQL from pg16 to pg18
- Add migration for `org_name` column on `user_api_keys` table
- Add `SSO_TOKEN_EXPIRE_DAYS` and `SSO_COOKIE_DOMAIN` to production.env template
- Add environment file to db services