### PR TITLE
feat: cross-app document API for service-to-service access

### DIFF
--- a/.github/instructions/copilot-cross-app.instructions.md
+++ b/.github/instructions/copilot-cross-app.instructions.md
@@ -1,0 +1,43 @@
+---
+description: "Use when working on cross-app service-to-service API, cross-app authentication, document access from external apps (team-manager), or the CROSS_APP_SECRET token system."
+applyTo: "services/backend/app/routers/cross_app*"
+---
+# Cross-App Document API
+
+## Overview
+Service-to-service API that allows team-manager (tm) to read markdown-manager (mm) documents on behalf of authenticated users. Mounted at `/api/cross-app/`.
+
+## Authentication
+**Not browser-facing.** Requests come from tm-backend over the Docker `shared-services` network.
+
+Two headers required on every request:
+- `X-Cross-App-Token` — shared secret matching `CROSS_APP_SECRET` env var (same value in both apps)
+- `X-User-Email` — email of the user whose documents to access
+
+Auth flow:
+1. `verify_cross_app_token()` — rejects if secret is empty (503) or mismatched (403)
+2. `get_cross_app_user()` — looks up mm User by email, rejects if not found (404) or inactive (403)
+3. All queries scoped to `user.id` — no cross-user access possible
+
+## Endpoints
+
+```
+GET  /api/cross-app/documents                 → List user's documents (metadata only, no content)
+GET  /api/cross-app/documents/semantic-search  → Semantic search with content excerpts (uses embedding service)
+GET  /api/cross-app/documents/{document_id}    → Full document content (owner check: document.user_id == user.id)
+```
+
+## Configuration
+- `CROSS_APP_SECRET` in `deployment/production.env` — must match the same var in team-manager
+- Setting defined in `app/configs/settings.py` as `cross_app_secret: str`
+- Router registered in `app/app_factory.py` with prefix `/cross-app`, tags `["cross-app"]`
+
+## Security Constraints
+- GitHub-synced documents are excluded from list results (`repository_type != "github"`)
+- The `/documents/{id}` endpoint explicitly checks `document.user_id != user.id` → 403
+- The endpoint is only reachable over the internal Docker network, not exposed via Traefik
+- Never log or expose the shared secret value
+
+## Calling Service (team-manager)
+See team-manager's `backend/app/services/mm_client.py` for the client implementation.
+The client sends `X-Cross-App-Token` and `X-User-Email` headers, uses in-memory TTL caching, and degrades gracefully when mm is unavailable.

--- a/deployment/production.env.template
+++ b/deployment/production.env.template
@@ -35,6 +35,11 @@ SSO_SECRET_KEY=CHANGE_ME_MUST_MATCH_OTHER_APP
 SSO_TOKEN_EXPIRE_DAYS=1
 SSO_COOKIE_DOMAIN=.littledan.com
 
+# ── Cross-App Service API ────────────────────────────────────────────────────
+# Shared secret for backend-to-backend API calls between apps (e.g. tm reading mm docs).
+# Must be identical in all apps that communicate. Generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
+CROSS_APP_SECRET=CHANGE_ME_MUST_MATCH_OTHER_APP
+
 # ── CORS ─────────────────────────────────────────────────────────────────────
 ALLOWED_ORIGINS=https://yourdomain.com
 

--- a/services/backend/app/app_factory.py
+++ b/services/backend/app/app_factory.py
@@ -44,6 +44,7 @@ from app.routers.admin import router as admin_router
 from app.routers import api_keys
 from app.routers import chat
 from app.routers import comments
+from app.routers import cross_app
 from app.routers import notifications
 from app.routers import ws as ws_router
 
@@ -161,6 +162,9 @@ def setup_routers(app: FastAPI) -> None:
     app.include_router(
         public.router, tags=["public"]
     )  # Public routes (no auth required)
+    app.include_router(
+        cross_app.router, prefix="/cross-app", tags=["cross-app"]
+    )  # Cross-app service-to-service API (token auth)
     app.include_router(
         auth.router, prefix="/auth", tags=["auth"]
     )  # Includes MFA endpoints at /auth/mfa/*

--- a/services/backend/app/configs/settings.py
+++ b/services/backend/app/configs/settings.py
@@ -71,6 +71,11 @@ class Settings(BaseSettings):
         default="markdown-manager", description="App identifier for JWT iss/aud claims"
     )
 
+    # Cross-app service-to-service auth
+    cross_app_secret: str = Field(
+        default="", description="Shared secret for cross-app backend-to-backend API calls"
+    )
+
     # SMTP configuration
     smtp_host: str = Field(default="smtp.example.com", description="SMTP server host")
     smtp_port: int = Field(

--- a/services/backend/app/routers/cross_app.py
+++ b/services/backend/app/routers/cross_app.py
@@ -1,0 +1,154 @@
+"""Cross-app API endpoints for service-to-service document access.
+
+These endpoints are authenticated via a shared secret (X-Cross-App-Token header)
+rather than user JWT tokens. The calling service passes X-User-Email to identify
+which user's documents to access.
+"""
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.configs import get_settings
+from app.crud import document as document_crud
+from app.crud.user import get_user_by_email
+from app.database import get_db
+from app.models.user import User
+from app.routers.documents.response_utils import create_document_response
+from app.schemas.document import DocumentResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+async def verify_cross_app_token(
+    x_cross_app_token: str = Header(..., description="Cross-app shared secret"),
+) -> None:
+    """Validate the cross-app service token."""
+    settings = get_settings()
+    if not settings.cross_app_secret:
+        raise HTTPException(status_code=503, detail="Cross-app API not configured")
+    if x_cross_app_token != settings.cross_app_secret:
+        raise HTTPException(status_code=403, detail="Invalid cross-app token")
+
+
+async def get_cross_app_user(
+    x_user_email: str = Header(..., description="Email of the user to act on behalf of"),
+    db: AsyncSession = Depends(get_db),
+    _token: None = Depends(verify_cross_app_token),
+) -> User:
+    """Look up the local user by email after verifying the cross-app token."""
+    user = await get_user_by_email(db, x_user_email)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found in Markdown Manager")
+    if not user.is_active:
+        raise HTTPException(status_code=403, detail="User account is inactive")
+    return user
+
+
+@router.get("/documents")
+async def list_documents(
+    folder_path: Optional[str] = Query(None, description="Filter by folder path"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
+    user: User = Depends(get_cross_app_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List documents for the identified user (metadata only, no content)."""
+    if folder_path:
+        from app.models.document import Document as DocumentModel
+        normalized = DocumentModel.normalize_folder_path(folder_path)
+        documents = await document_crud.document.get_documents_by_folder_path(
+            db, user.id, normalized
+        )
+        documents = documents[skip:skip + limit]
+    else:
+        documents = await document_crud.document.get_by_user(
+            db=db, user_id=user.id, skip=skip, limit=limit
+        )
+
+    return [
+        {
+            "id": doc.id,
+            "name": doc.name,
+            "folder_path": doc.folder_path or "/",
+            "category_name": getattr(doc, "category", None),
+            "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+            "created_at": doc.created_at.isoformat() if doc.created_at else None,
+        }
+        for doc in documents
+        if doc.repository_type != "github"  # Only local documents
+    ]
+
+
+@router.get("/documents/semantic-search")
+async def semantic_search(
+    q: str = Query(..., min_length=1, description="Search query"),
+    limit: int = Query(10, ge=1, le=50),
+    user: User = Depends(get_cross_app_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Semantic search across the user's documents."""
+    from app.services.search.semantic import SemanticSearchService
+    from app.services.search.embedding_client import EmbeddingClient
+
+    settings = get_settings()
+    client = EmbeddingClient(base_url=settings.embedding_service_url)
+    try:
+        import redis.asyncio as aioredis
+        redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
+    except Exception:
+        redis_client = None
+
+    service = SemanticSearchService(client, redis_client=redis_client)
+    results = await service.search(db, user.id, q, limit=limit)
+
+    response = []
+    for result in results:
+        doc = result.document
+        # Load content for excerpt
+        doc_response = await create_document_response(
+            document=doc, user_id=user.id, db=db
+        )
+        content = doc_response.content or ""
+        response.append({
+            "id": doc.id,
+            "name": doc.name,
+            "folder_path": doc.folder_path or "/",
+            "category_name": getattr(doc, "category", None),
+            "content_excerpt": content[:500] if content else "",
+            "score": result.score,
+            "updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+        })
+
+    return response
+
+
+@router.get("/documents/{document_id}")
+async def get_document(
+    document_id: int,
+    user: User = Depends(get_cross_app_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a single document with full content."""
+    document = await document_crud.document.get(db=db, id=document_id)
+    if not document:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if document.user_id != user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    doc_response = await create_document_response(
+        document=document, user_id=user.id, db=db
+    )
+
+    return {
+        "id": doc_response.id,
+        "name": doc_response.name,
+        "content": doc_response.content,
+        "folder_path": doc_response.folder_path,
+        "category_name": doc_response.category_name,
+        "updated_at": doc_response.updated_at.isoformat() if doc_response.updated_at else None,
+        "created_at": doc_response.created_at.isoformat() if doc_response.created_at else None,
+    }

--- a/services/ui/src/api/userApi.js
+++ b/services/ui/src/api/userApi.js
@@ -15,6 +15,7 @@ class UserAPI extends Api {
   }
 
   // Request a new access token using the refresh token cookie
+  // Returns: { access_token, ... } on success, null on auth failure, { transient: true } on 502-504
   async refreshToken() {
     try {
       console.log('UserAPI.refreshToken: Attempting refresh with credentials');
@@ -28,12 +29,17 @@ class UserAPI extends Api {
       if (error?.response?.status === 401 || error?.response?.status === 403) {
         return null;
       }
-      // Transient proxy/server errors (backend restarting) — return null so callers can retry
+      // Transient proxy/server errors (backend restarting) — signal callers to retry
       if (error?.response?.status >= 502 && error?.response?.status <= 504) {
         console.warn('UserAPI.refreshToken: Transient server error, backend may be restarting');
-        return null;
+        return { transient: true };
       }
-      // Log other errors (500, network issues, etc.)
+      // Network errors (no response at all) are also transient
+      if (error?.code === 'ERR_NETWORK' || !error?.response) {
+        console.warn('UserAPI.refreshToken: Network error, backend may be unavailable');
+        return { transient: true };
+      }
+      // Log other errors (500, etc.)
       console.error("Token refresh failed:", error);
       throw error;
     }

--- a/services/ui/src/components/help/GuidedTour.jsx
+++ b/services/ui/src/components/help/GuidedTour.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Joyride, ACTIONS, STATUS, EVENTS } from 'react-joyride';
+import { Joyride, STATUS } from 'react-joyride';
 import tourSteps from './tourSteps';
 
 const TOUR_COMPLETED_KEY = 'mm-tour-completed';
@@ -31,41 +31,24 @@ function getThemeColors() {
 /**
  * GuidedTour — interactive walkthrough using react-joyride.
  *
+ * Uses uncontrolled mode (no stepIndex) so Joyride handles all
+ * step navigation, target resolution, and scrolling internally.
+ *
  * Props:
  *  - run: boolean, when true the tour starts
  *  - onFinish: callback when tour ends (completed or skipped)
  */
 function GuidedTour({ run, onFinish }) {
-  const [stepIndex, setStepIndex] = useState(0);
-
   // Snapshot theme colors when tour starts so they stay consistent
   const colors = useMemo(() => {
-    if (!run) return getThemeColors();
     return getThemeColors();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [run]);
 
-  // Reset step when tour restarts
-  useEffect(() => {
-    if (run) setStepIndex(0);
-  }, [run]);
-
   const handleCallback = useCallback((data) => {
-    const { status, type, index, action } = data;
+    const { status } = data;
 
-    // Advance to next / previous step
-    if (type === EVENTS.STEP_AFTER) {
-      setStepIndex(index + (action === ACTIONS.PREV ? -1 : 1));
-      return;
-    }
-
-    // If a target element is missing, skip forward past it
-    if (type === EVENTS.TARGET_NOT_FOUND) {
-      setStepIndex(index + 1);
-      return;
-    }
-
-    // End tour only on authoritative status changes (finish, skip, close, escape, overlay click)
+    // End tour on finish, skip, close button, Escape, or overlay click
     if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
       localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
       onFinish?.();
@@ -76,7 +59,6 @@ function GuidedTour({ run, onFinish }) {
     <Joyride
       steps={tourSteps}
       run={run}
-      stepIndex={stepIndex}
       continuous
       showSkipButton
       showProgress

--- a/services/ui/src/components/help/GuidedTour.jsx
+++ b/services/ui/src/components/help/GuidedTour.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Joyride, STATUS, EVENTS } from 'react-joyride';
+import { Joyride, ACTIONS, STATUS, EVENTS } from 'react-joyride';
 import tourSteps from './tourSteps';
 
 const TOUR_COMPLETED_KEY = 'mm-tour-completed';
@@ -53,15 +53,20 @@ function GuidedTour({ run, onFinish }) {
   const handleCallback = useCallback((data) => {
     const { status, type, index, action } = data;
 
+    // Advance to next / previous step
     if (type === EVENTS.STEP_AFTER) {
-      setStepIndex(index + 1);
+      setStepIndex(index + (action === ACTIONS.PREV ? -1 : 1));
+      return;
     }
 
-    // Close on skip, finish, or explicit close action
-    if (
-      [STATUS.FINISHED, STATUS.SKIPPED].includes(status) ||
-      action === 'close'
-    ) {
+    // If a target element is missing, skip forward past it
+    if (type === EVENTS.TARGET_NOT_FOUND) {
+      setStepIndex(index + 1);
+      return;
+    }
+
+    // End tour only on authoritative status changes (finish, skip, close, escape, overlay click)
+    if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
       localStorage.setItem(TOUR_COMPLETED_KEY, 'true');
       onFinish?.();
     }

--- a/services/ui/src/services/core/AuthService.js
+++ b/services/ui/src/services/core/AuthService.js
@@ -53,12 +53,22 @@ class AuthService {
       console.log('AuthService: Attempting refresh token');
       let refreshResult = await UserAPI.refreshToken();
 
-      // If refresh returned null but we were previously authenticated, retry once
-      // after a short delay — the backend may be restarting during a deployment
-      if (!refreshResult && localStorage.getItem('lastKnownAuthState') === 'authenticated') {
-        console.log('AuthService: Refresh returned null for previously authenticated user, retrying in 2s');
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        refreshResult = await UserAPI.refreshToken();
+      // If refresh hit a transient error (502/503/504 or network), retry with backoff.
+      // This handles the window during blue/green deployments where the backend is
+      // briefly unavailable before the new container becomes healthy.
+      if (refreshResult?.transient && localStorage.getItem('lastKnownAuthState') === 'authenticated') {
+        const retryDelays = [2000, 4000, 6000];
+        for (const delay of retryDelays) {
+          console.log(`AuthService: Transient error, retrying refresh in ${delay / 1000}s`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          refreshResult = await UserAPI.refreshToken();
+          if (!refreshResult?.transient) break;
+        }
+      }
+
+      // Normalize transient sentinel to null if all retries exhausted
+      if (refreshResult?.transient) {
+        refreshResult = null;
       }
 
       if (refreshResult && refreshResult.access_token) {


### PR DESCRIPTION
Adds `/api/cross-app/` endpoints so team-manager can read mm documents on behalf of authenticated users.

## Changes
- New `cross_app.py` router with list, detail, and semantic-search endpoints
- Auth via shared `CROSS_APP_SECRET` header + user email lookup
- `cross_app_secret` added to settings
- Copilot instruction file for the cross-app subsystem
- Also includes: auth retry backoff fix, guided tour fix

## Security
- All queries scoped to `user.id` — no cross-user access
- Only reachable over internal Docker network
- GitHub-synced documents excluded from results