### PR TITLE
feat: breadcrumb-style category navigation with move-to-category icon

### DIFF
--- a/services/ui/src/components/toolbar/Document.jsx
+++ b/services/ui/src/components/toolbar/Document.jsx
@@ -1,5 +1,5 @@
 import DeleteCategoryModal from "@/components/document/modals/DeleteCategoryModal";
-import React, { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import ConfirmModal from "@/components/shared/modals/ConfirmModal";
 import { useConfirmModal } from "@/hooks/ui";
 import { Dropdown, OverlayTrigger, Popover } from "react-bootstrap";
@@ -58,67 +58,37 @@ function DocumentToolbar({ documentTitle: _documentTitle, setDocumentTitle }) {
     }, 1000);
   }, [getLastSavedText]);
 
-  // Tracks a user-initiated category selection that hasn't yet been reflected
-  // in currentDocument.category (i.e. the save is still in-flight).
-  // Stores { category, documentId } so the guard is scoped to the document being saved.
-  // Cleared when currentDocument.category catches up, or when the user switches documents.
-  const pendingCategoryRef = useRef(null);
+  // Navigate to a category (open first document in that category)
+  const handleCategorySelect = (category) => {
+    clearSiblingOverride();
+    openCategory(category);
+  };
 
-  // Save document immediately when changing category (only for local files)
-  const handleCategorySelect = async (category) => {
-    // Don't allow category changes for GitHub files
-    if (currentDocument?.repository_type === 'github') {
-      return;
-    }
+  // Move current document to a different category (save-based reassignment)
+  const handleMoveToCategory = async (category) => {
+    if (currentDocument?.repository_type === 'github') return;
+    if (category === currentCategory) return;
 
-    pendingCategoryRef.current = { category, documentId: currentDocument?.id };
     setCurrentCategory(category);
     try {
       const updatedDoc = { ...currentDocument, category };
       await saveDocument(updatedDoc);
-      // The saveDocument in DocumentProvider will handle current document tracking
+      refreshSiblings();
     } catch (err) {
-      // Revert dropdown to document's actual category on failure
-      pendingCategoryRef.current = null;
       setCurrentCategory(currentDocument?.category || 'General');
-      showError("Failed to update document category.");
+      showError("Failed to move document to category.");
     }
   };
 
-  // Sync category with currentDocument.category whenever document changes (local files only)
+  // Sync currentCategory from document state
   useEffect(() => {
-    // Skip category management entirely for GitHub files
-    if (currentDocument?.repository_type === 'github') {
-      return;
+    if (currentDocument?.repository_type === 'github') return;
+    if (currentDocument?.category) {
+      setCurrentCategory(
+        categories.includes(currentDocument.category) ? currentDocument.category : 'General'
+      );
     }
-
-    if (currentDocument && currentDocument.category) {
-      // If a user-initiated category change is pending, check whether the
-      // pending change is still relevant for the current document
-      if (pendingCategoryRef.current !== null) {
-        if (currentDocument.id !== pendingCategoryRef.current.documentId) {
-          // User switched to a different document — pending change is irrelevant.
-          // Clear it and fall through to sync from the new document's category.
-          pendingCategoryRef.current = null;
-        } else if (currentDocument.category === pendingCategoryRef.current.category) {
-          // Save completed for THIS document — category caught up, clear pending
-          pendingCategoryRef.current = null;
-          return; // Optimistic value is already correct
-        } else {
-          // Still pending for this document — don't override the optimistic update
-          return;
-        }
-      }
-
-      // No pending change — sync dropdown from document state (external change)
-      if (!categories.includes(currentDocument.category)) {
-        setCurrentCategory("General");
-      } else {
-        setCurrentCategory(currentDocument.category);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omit currentCategory to prevent bounce-back on optimistic updates
-  }, [currentDocument?.category, currentDocument?.updated_at, currentDocument?.repository_type, categories, currentDocument]);
+  }, [currentDocument?.category, currentDocument?.repository_type, categories]);
 
   const handleTitleClick = () => () => {
     setTitleInput(currentDocument.name || "Untitled Document");
@@ -279,13 +249,13 @@ function DocumentToolbar({ documentTitle: _documentTitle, setDocumentTitle }) {
           {currentDocument.category || 'General'}
         </span>
       ) : (
-        /* Category dropdown with inline rename for local files */
-        <Dropdown as="span" className="me-1">
+        /* Category breadcrumb dropdown — navigation-primary */
+        <Dropdown as="span" className="me-1 category-breadcrumb">
           <Dropdown.Toggle
-            size="sm"
-            variant="secondary"
+            as="span"
             id="categoryDropdown"
-            className="dropdown-toggle d-flex align-items-center"
+            className="category-breadcrumb-toggle"
+            role="button"
           >
             {editingCategory ? (
               <input
@@ -310,30 +280,15 @@ function DocumentToolbar({ documentTitle: _documentTitle, setDocumentTitle }) {
             )}
           </Dropdown.Toggle>
           <Dropdown.Menu>
-            {/* Recent — virtual category */}
+            {/* Recent — virtual navigation category */}
             <Dropdown.Item
               key="__recents__"
               active={siblingOverrideMode === 'recents'}
-              onClick={(e) => e.preventDefault()}
+              onClick={() => openRecents()}
               className={`d-flex justify-content-between align-items-center
                   ${siblingOverrideMode === 'recents' ? "text-bg-secondary" : ""}`}
             >
               <span className="text-truncate"><i className="bi bi-clock-history me-1"></i>Recent</span>
-              <span className="d-flex align-items-center gap-1 ms-2">
-                <button
-                  type="button"
-                  className="btn btn-link btn-sm p-0 text-muted"
-                  title="Open Recent"
-                  tabIndex={-1}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openRecents();
-                  }}
-                  aria-label="Open Recent"
-                >
-                  <i className="bi bi-folder2-open"></i>
-                </button>
-              </span>
             </Dropdown.Item>
             <Dropdown.Divider />
             {categories.map((category) => (
@@ -346,20 +301,6 @@ function DocumentToolbar({ documentTitle: _documentTitle, setDocumentTitle }) {
               >
                 <span className="text-truncate">{category}</span>
                 <span className="d-flex align-items-center gap-1 ms-2">
-                  <button
-                    type="button"
-                    className="btn btn-link btn-sm p-0 text-muted"
-                    title={`Open ${category}`}
-                    tabIndex={-1}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      clearSiblingOverride();
-                      openCategory(category);
-                    }}
-                    aria-label={`Open ${category}`}
-                  >
-                    <i className="bi bi-folder2-open"></i>
-                  </button>
                   {category !== "General" && category !== "Drafts" && (
                     <button
                       type="button"
@@ -411,7 +352,7 @@ function DocumentToolbar({ documentTitle: _documentTitle, setDocumentTitle }) {
           </Dropdown.Menu>
         </Dropdown>
       )}
-      <span className="mx-1 text-muted">/</span>
+      <span className="mx-1 text-muted breadcrumb-separator">›</span>
       {editingTitle && !isCollabDocument ? (
         <input
           type="text"
@@ -433,6 +374,36 @@ function DocumentToolbar({ documentTitle: _documentTitle, setDocumentTitle }) {
         >
           {currentDocument.name || "Untitled Document"}
         </span>
+      )}
+      {/* Move to category button — local docs only */}
+      {!isGitHubFile && !isCollabDocument && (
+        <Dropdown as="span" className="ms-1 move-to-category">
+          <Dropdown.Toggle
+            as="span"
+            id="moveCategoryDropdown"
+            className="move-category-toggle"
+            role="button"
+            title="Move to category"
+          >
+            <i className="bi bi-folder-symlink"></i>
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            <Dropdown.Header>Move to category</Dropdown.Header>
+            {categories.map((category) => (
+              <Dropdown.Item
+                key={category}
+                active={category === currentCategory}
+                onClick={() => handleMoveToCategory(category)}
+                disabled={category === currentCategory}
+              >
+                {category === currentCategory && (
+                  <i className="bi bi-check-lg me-1"></i>
+                )}
+                {category}
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Menu>
+        </Dropdown>
       )}
       <span className="vr opacity-50 mx-2"></span>
       {/* Document status popover */}

--- a/services/ui/src/components/toolbar/MobileToolbarMenu.jsx
+++ b/services/ui/src/components/toolbar/MobileToolbarMenu.jsx
@@ -19,6 +19,7 @@ function MobileToolbarMenu({
   onDocumentInfo,
   onRenameDocument,
   onChangeCategory,
+  onOpenCategory,
   fullscreenPreview,
   theme,
   currentDocument,
@@ -27,6 +28,7 @@ function MobileToolbarMenu({
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleInput, setTitleInput] = useState('');
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
+  const [categoryPickerMode, setCategoryPickerMode] = useState('navigate'); // 'navigate' | 'move'
 
   const handleAction = (action) => {
     action();
@@ -57,11 +59,18 @@ function MobileToolbarMenu({
   }, [handleTitleSave]);
 
   const handleCategorySelect = useCallback((category) => {
-    if (onChangeCategory) {
-      onChangeCategory(category);
+    if (categoryPickerMode === 'move') {
+      if (onChangeCategory && category !== currentDocument?.category) {
+        onChangeCategory(category);
+      }
+    } else {
+      if (onOpenCategory) {
+        onOpenCategory(category);
+        onHide();
+      }
     }
     setShowCategoryPicker(false);
-  }, [onChangeCategory]);
+  }, [categoryPickerMode, onChangeCategory, onOpenCategory, onHide, currentDocument?.category]);
 
   const isGitHubFile = currentDocument?.repository_type === 'github';
 
@@ -104,34 +113,55 @@ function MobileToolbarMenu({
                       {currentDocument.github_repository?.name || 'GitHub'}
                     </span>
                   ) : (
-                    <button
-                      type="button"
-                      className="doc-category-btn"
-                      onClick={() => setShowCategoryPicker(!showCategoryPicker)}
-                      title="Tap to change category"
-                    >
-                      <span className="badge bg-secondary">
-                        {currentDocument.category || 'General'}
-                        <i className="bi bi-pencil-fill ms-1" style={{ fontSize: '0.6em' }} />
-                      </span>
-                    </button>
+                    <span className="d-flex align-items-center gap-1">
+                      <button
+                        type="button"
+                        className="doc-category-btn"
+                        onClick={() => {
+                          setCategoryPickerMode('navigate');
+                          setShowCategoryPicker(!showCategoryPicker);
+                        }}
+                        title="Tap to navigate to category"
+                      >
+                        <span className="badge bg-secondary">
+                          {currentDocument.category || 'General'}
+                          <i className="bi bi-chevron-down ms-1" style={{ fontSize: '0.6em' }} />
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        className="doc-category-btn"
+                        onClick={() => {
+                          setCategoryPickerMode('move');
+                          setShowCategoryPicker(!showCategoryPicker);
+                        }}
+                        title="Move document to category"
+                      >
+                        <i className="bi bi-folder-symlink" style={{ fontSize: '0.8em', opacity: 0.6 }} />
+                      </button>
+                    </span>
                   )}
                 </div>
 
                 {/* Category picker */}
                 {showCategoryPicker && !isGitHubFile && categories && (
-                  <ul className="mobile-category-list">
-                    {categories.map((cat) => (
-                      <li
-                        key={cat}
-                        className={cat === currentDocument.category ? 'active' : ''}
-                        onClick={() => handleCategorySelect(cat)}
-                      >
-                        <i className={`bi bi-${cat === currentDocument.category ? 'check-circle-fill' : 'circle'}`} />
-                        {cat}
-                      </li>
-                    ))}
-                  </ul>
+                  <>
+                    <div className="small text-muted px-2 mt-1 mb-1">
+                      {categoryPickerMode === 'move' ? 'Move document to:' : 'Navigate to category:'}
+                    </div>
+                    <ul className="mobile-category-list">
+                      {categories.map((cat) => (
+                        <li
+                          key={cat}
+                          className={cat === currentDocument.category ? 'active' : ''}
+                          onClick={() => handleCategorySelect(cat)}
+                        >
+                          <i className={`bi bi-${cat === currentDocument.category ? 'check-circle-fill' : 'circle'}`} />
+                          {cat}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
                 )}
               </div>
 
@@ -227,6 +257,7 @@ MobileToolbarMenu.propTypes = {
   onDocumentInfo: PropTypes.func,
   onRenameDocument: PropTypes.func,
   onChangeCategory: PropTypes.func,
+  onOpenCategory: PropTypes.func,
   fullscreenPreview: PropTypes.bool.isRequired,
   theme: PropTypes.string.isRequired,
   currentDocument: PropTypes.object,

--- a/services/ui/src/components/toolbar/Toolbar.jsx
+++ b/services/ui/src/components/toolbar/Toolbar.jsx
@@ -29,7 +29,7 @@ function Toolbar({
   setShowIconBrowser
 }) {
   const { theme, setTheme } = useTheme();
-  const { currentDocument, error: _error, isSharedView, sharedDocument, sharedLoading, sharedError: _sharedError, previewHTML, setShowChatDrawer, categories, saveDocument, renameDocument, content, mobileViewMode, setMobileViewMode, loadDocument } = useDocumentContext();
+  const { currentDocument, error: _error, isSharedView, sharedDocument, sharedLoading, sharedError: _sharedError, previewHTML, setShowChatDrawer, categories, saveDocument, renameDocument, content, mobileViewMode, setMobileViewMode, loadDocument, openCategory, clearSiblingOverride } = useDocumentContext();
   const { showWarning: _showWarning } = useNotification();
   const { user } = useAuth();
   const { isMobile } = useViewport();
@@ -98,6 +98,11 @@ function Toolbar({
     if (!currentDocument || currentDocument.repository_type === 'github') return;
     await saveDocument({ ...currentDocument, category });
   }, [currentDocument, saveDocument]);
+
+  const handleMobileOpenCategory = useCallback((category) => {
+    clearSiblingOverride();
+    openCategory(category);
+  }, [clearSiblingOverride, openCategory]);
 
   const handleViewNotificationDetail = useCallback(async (notification) => {
     if (!notification.is_read) markRead(notification.id);
@@ -334,6 +339,7 @@ function Toolbar({
           onDocumentInfo={handleShowDocumentInfo}
           onRenameDocument={handleMobileRename}
           onChangeCategory={handleMobileCategoryChange}
+          onOpenCategory={handleMobileOpenCategory}
           fullscreenPreview={fullscreenPreview}
           theme={theme}
           currentDocument={currentDocument}

--- a/services/ui/src/styles/toolbar/_navigation.scss
+++ b/services/ui/src/styles/toolbar/_navigation.scss
@@ -154,3 +154,93 @@
     }
   }
 }
+
+// ─── CATEGORY BREADCRUMB DROPDOWN ───
+// Breadcrumb-styled dropdown toggle for category navigation
+.category-breadcrumb {
+  display: inline-flex;
+  align-items: center;
+}
+
+.category-breadcrumb-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: transparent !important;
+  border: none !important;
+  color: var(--mm-text);
+  font-size: variables.$font-size-base;
+  font-weight: variables.$font-weight-medium;
+  padding: variables.$space-1 variables.$space-2;
+  border-radius: variables.$radius-md;
+  cursor: pointer;
+  @include mixins.interactive-transition(background-color, color);
+
+  &:hover {
+    background-color: var(--mm-bg-surface) !important;
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--mm-primary);
+    outline: none;
+  }
+
+  // Dropdown caret
+  &::after {
+    display: inline-block;
+    margin-left: 0.2em;
+    vertical-align: 0.15em;
+    content: "";
+    border-top: 0.3em solid;
+    border-right: 0.3em solid transparent;
+    border-bottom: 0;
+    border-left: 0.3em solid transparent;
+    opacity: 0.6;
+  }
+}
+
+// Breadcrumb separator between category and title
+.breadcrumb-separator {
+  font-size: 1.1em;
+  opacity: 0.5;
+  user-select: none;
+}
+
+// ─── MOVE TO CATEGORY DROPDOWN ───
+.move-to-category {
+  display: inline-flex;
+  align-items: center;
+}
+
+.move-category-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent !important;
+  border: none !important;
+  color: var(--mm-text-muted, var(--bs-text-muted));
+  font-size: 0.8rem;
+  padding: 0.125rem 0.25rem;
+  border-radius: variables.$radius-sm;
+  cursor: pointer;
+  opacity: 0.5;
+  @include mixins.interactive-transition(background-color, color, opacity);
+
+  &:hover {
+    opacity: 1;
+    background-color: var(--mm-bg-surface) !important;
+    color: var(--mm-primary);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--mm-primary);
+    outline: none;
+    opacity: 1;
+  }
+
+  // Hide the default dropdown caret
+  &::after {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Restyle the header category dropdown from assignment control to navigation breadcrumb. Clicking a category now navigates to that category (loads first doc, updates sibling tabs) instead of reassigning the current document.

- Restyle dropdown toggle: transparent breadcrumb appearance with caret
- Replace '/' separator with '›' breadcrumb chevron
- Category click calls openCategory() for navigation
- Remove pendingCategoryRef optimistic-update machinery
- Add move-to-category icon (bi-folder-symlink) next to document title with dropdown for document reassignment (local docs only)
- Simplify Recent item: direct click navigates (remove nested button)
- Remove per-row folder-open icons (redundant with click-to-navigate)
- Update mobile toolbar: badge tap navigates, separate move icon
- Pass openCategory/clearSiblingOverride to mobile menu via Toolbar