### PR TITLE
docs: add tabular export endpoints to export service instructions

### DIFF
--- a/.github/instructions/copilot-service-export.instructions.md
+++ b/.github/instructions/copilot-service-export.instructions.md
@@ -34,6 +34,10 @@ location /api/export/ {
 | `/diagram/png` | POST | Rendered diagram → PNG |
 | `/diagram/drawio/xml` | POST | Mermaid → Draw.io XML |
 | `/diagram/drawio/png` | POST | Mermaid → Draw.io editable PNG |
+| `/tabular/csv` | POST | Tabular data → CSV |
+| `/tabular/xlsx` | POST | Tabular data → XLSX (single sheet) |
+| `/tabular/xlsx/multi` | POST | Tabular data → XLSX (multi-sheet) |
+| `/tabular/markdown` | POST | Tabular data → Markdown table |
 
 ## Important
 - Do NOT add export service source code to this repo


### PR DESCRIPTION
## Summary

Update the MM copilot export service instructions to document the new tabular export endpoints added in platform-manager.

## Changes
- Added 4 new endpoints to the available endpoints table: `/tabular/csv`, `/tabular/xlsx`, `/tabular/xlsx/multi`, `/tabular/markdown`

## Related PRs
- **Platform Manager**: LittleDan9/platform-manager#3 (adds the endpoints)
- **Team Manager**: LittleDan9/team-manager#6 (first consumer)